### PR TITLE
Create cache-deps.yaml

### DIFF
--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -1,0 +1,31 @@
+name: Build dependency cache on main branch
+on:
+  push:
+    branches: main
+    paths:
+      - '.github/workflows/cache-deps.yaml'
+  schedule:
+    - cron: "10 16 * * *"
+
+jobs:
+  build-deps-cache-on-main:
+    if: github.repository_owner == 'cdcepi'
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          install-r: false
+          use-public-rspm: true
+
+      - name: Update R
+        run: |
+          sudo apt-get update
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: Infectious-Disease-Modeling-Hubs/hubValidations, any::sessioninfo


### PR DESCRIPTION
I noticed that none of the new PRs were able to access the cache of the dependencies introduced in the updated `validate-submission.yaml` workflow.

After some digging I realised not [all caches all accessible to different branches](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) (for sound security reasons) and that there wasn't a cache built on the main branch available for child branches to load.

So I developed a GA that builds a new dependency cache (if necessary, i.e. if there are upgrades to any OS release, R or R package dependencies) on `main` nightly only in the `cdcepi` repo. It will also run any time a change is pushed to the file itself which ensures it triggers the first time it is added.