### PR TITLE
pin ubuntu 22.04 to workflows.

### DIFF
--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-deps-cache-on-main:
     if: github.repository_owner == 'cdcepi'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cache-hubval-deps.yaml
+++ b/.github/workflows/cache-hubval-deps.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-deps-cache-on-main:
     if: ${{ github.repository_owner == github.repository_owner }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-hub-config:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   validate-submission:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
GitHub is rolling out its default ubuntu runner to remove a bunch of
installed software including R.

This is a temporary fix. See https://github.com/cdcepi/FluSight-forecast-hub/pull/1251#issuecomment-2536593645
for details
