### PR TITLE
Revert "switch to v4; fix schema org URL"

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/admin-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v3.0.1/admin-schema.json",
     "name": "US CDC FluSight",
     "maintainer": "US CDC",
     "contact": {

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v3.0.1/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,
@@ -116,6 +116,7 @@
                                 "2025-04-26", "2025-05-03", "2025-05-10", "2025-05-17", 
                                 "2025-05-24", "2025-05-31", "2025-06-07", "2025-06-14",
                                 "2025-06-21"
+
                             ]
                         }
                     },
@@ -128,14 +129,14 @@
                                     "stable",
                                     "increase",
                                     "large_increase"
-                                ]
+                                ],
+                                "optional": null
                             },
                             "value": {
                                 "type": "double",
                                 "minimum": 0,
                                 "maximum": 1
-                            },
-                            "is_required": true
+                            }
                         }
                     },
                     "target_metadata": [
@@ -295,16 +296,17 @@
                                     0.95,
                                     0.975,
                                     0.99
-                                ]
+                                ],
+                                "optional": null
                             },
                             "value": {
                                 "type": "double",
                                 "minimum": 0
-                            },
-                            "is_required": true
+                            }
                         },
                         "sample": {
                             "output_type_id_params": {
+                                "is_required": false,
                                 "type": "integer",
                                 "min_samples_per_task": 100,
                                 "max_samples_per_task": 100,
@@ -313,8 +315,7 @@
                             "value": {
                                 "type": "integer",
                                 "minimum": 0
-                            },
-                            "is_required": false
+                            }
                         }
                     },
                     "target_metadata": [
@@ -453,13 +454,13 @@
                                     0.95,
                                     0.975,
                                     0.99
-                                ]
+                                ],
+                                "optional": null
                             },
                             "value": {
                                 "type": "double",
                                 "minimum": 0
-                            },
-                            "is_required": true
+                            }
                         }
                     },
                     "target_metadata": [
@@ -584,14 +585,14 @@
                                     "2025-04-05", "2025-04-12", "2025-04-19",
                                     "2025-04-26", "2025-05-03", "2025-05-10",
                                     "2025-05-17", "2025-05-24", "2025-05-31"
-                                ]
+                                ],
+                                "optional": null
                             },
                             "value": {
                                 "type": "double",
                                 "minimum": 0,
                                 "maximum": 1
-                            },
-                            "is_required": true
+                            }
                         }
                     },
                     "target_metadata": [
@@ -615,6 +616,5 @@
                 "end": -3
             }
         }
-    ],
-    "derived_task_ids": ["target_end_date"]
+    ]
 }


### PR DESCRIPTION
This reverts commit 4ef66b8c523c02d10cfa8327ba3c9bc8b6fdbc0a.

See https://github.com/cdcepi/FluSight-forecast-hub/pull/1261#issuecomment-2537242929 for details and rationale.
