### PR TITLE
Prevent AWS upload job from running on a forked repo

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   upload:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
This change skips the AWS upload GitHub action for forked repos, which will not have permissions to push data to the primary hub's S3 bucket.