### PR TITLE
2025-01-25 forecasts for SigSci-TSENS

### DIFF
--- a/model-output/SigSci-TSENS/2025-01-25-SigSci-TSENS.csv
+++ b/model-output/SigSci-TSENS/2025-01-25-SigSci-TSENS.csv
@@ -1,0 +1,5713 @@
+reference_date,horizon,target,target_end_date,location,output_type,output_type_id,value
+2025-01-25,0,wk flu hosp rate change,2025-01-25,01,pmf,stable,0.084
+2025-01-25,0,wk flu hosp rate change,2025-01-25,01,pmf,increase,0.205
+2025-01-25,0,wk flu hosp rate change,2025-01-25,01,pmf,large_increase,0.336
+2025-01-25,0,wk flu hosp rate change,2025-01-25,01,pmf,decrease,0.175
+2025-01-25,0,wk flu hosp rate change,2025-01-25,01,pmf,large_decrease,0.2
+2025-01-25,1,wk flu hosp rate change,2025-02-01,01,pmf,stable,0.115
+2025-01-25,1,wk flu hosp rate change,2025-02-01,01,pmf,increase,0.269
+2025-01-25,1,wk flu hosp rate change,2025-02-01,01,pmf,large_increase,0.252
+2025-01-25,1,wk flu hosp rate change,2025-02-01,01,pmf,decrease,0.221
+2025-01-25,1,wk flu hosp rate change,2025-02-01,01,pmf,large_decrease,0.143
+2025-01-25,2,wk flu hosp rate change,2025-02-08,01,pmf,stable,0.132
+2025-01-25,2,wk flu hosp rate change,2025-02-08,01,pmf,increase,0.283
+2025-01-25,2,wk flu hosp rate change,2025-02-08,01,pmf,large_increase,0.213
+2025-01-25,2,wk flu hosp rate change,2025-02-08,01,pmf,decrease,0.239
+2025-01-25,2,wk flu hosp rate change,2025-02-08,01,pmf,large_decrease,0.133
+2025-01-25,3,wk flu hosp rate change,2025-02-15,01,pmf,stable,0.159
+2025-01-25,3,wk flu hosp rate change,2025-02-15,01,pmf,increase,0.285
+2025-01-25,3,wk flu hosp rate change,2025-02-15,01,pmf,large_increase,0.191
+2025-01-25,3,wk flu hosp rate change,2025-02-15,01,pmf,decrease,0.242
+2025-01-25,3,wk flu hosp rate change,2025-02-15,01,pmf,large_decrease,0.123
+2025-01-25,0,wk flu hosp rate change,2025-01-25,02,pmf,stable,0.625
+2025-01-25,0,wk flu hosp rate change,2025-01-25,02,pmf,increase,0.05
+2025-01-25,0,wk flu hosp rate change,2025-01-25,02,pmf,large_increase,0.15
+2025-01-25,0,wk flu hosp rate change,2025-01-25,02,pmf,decrease,0.052
+2025-01-25,0,wk flu hosp rate change,2025-01-25,02,pmf,large_decrease,0.123
+2025-01-25,1,wk flu hosp rate change,2025-02-01,02,pmf,stable,0.551
+2025-01-25,1,wk flu hosp rate change,2025-02-01,02,pmf,increase,0.174
+2025-01-25,1,wk flu hosp rate change,2025-02-01,02,pmf,large_increase,0.05
+2025-01-25,1,wk flu hosp rate change,2025-02-01,02,pmf,decrease,0.183
+2025-01-25,1,wk flu hosp rate change,2025-02-01,02,pmf,large_decrease,0.042
+2025-01-25,2,wk flu hosp rate change,2025-02-08,02,pmf,stable,0.501
+2025-01-25,2,wk flu hosp rate change,2025-02-08,02,pmf,increase,0.203
+2025-01-25,2,wk flu hosp rate change,2025-02-08,02,pmf,large_increase,0.021
+2025-01-25,2,wk flu hosp rate change,2025-02-08,02,pmf,decrease,0.245
+2025-01-25,2,wk flu hosp rate change,2025-02-08,02,pmf,large_decrease,0.03
+2025-01-25,3,wk flu hosp rate change,2025-02-15,02,pmf,stable,0.469
+2025-01-25,3,wk flu hosp rate change,2025-02-15,02,pmf,increase,0.223
+2025-01-25,3,wk flu hosp rate change,2025-02-15,02,pmf,large_increase,0.008
+2025-01-25,3,wk flu hosp rate change,2025-02-15,02,pmf,decrease,0.3
+2025-01-25,3,wk flu hosp rate change,2025-02-15,02,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,04,pmf,stable,0.091
+2025-01-25,0,wk flu hosp rate change,2025-01-25,04,pmf,increase,0.009
+2025-01-25,0,wk flu hosp rate change,2025-01-25,04,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,04,pmf,decrease,0.788
+2025-01-25,0,wk flu hosp rate change,2025-01-25,04,pmf,large_decrease,0.112
+2025-01-25,1,wk flu hosp rate change,2025-02-01,04,pmf,stable,0.18
+2025-01-25,1,wk flu hosp rate change,2025-02-01,04,pmf,increase,0.035
+2025-01-25,1,wk flu hosp rate change,2025-02-01,04,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,04,pmf,decrease,0.747
+2025-01-25,1,wk flu hosp rate change,2025-02-01,04,pmf,large_decrease,0.038
+2025-01-25,2,wk flu hosp rate change,2025-02-08,04,pmf,stable,0.189
+2025-01-25,2,wk flu hosp rate change,2025-02-08,04,pmf,increase,0.034
+2025-01-25,2,wk flu hosp rate change,2025-02-08,04,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,04,pmf,decrease,0.737
+2025-01-25,2,wk flu hosp rate change,2025-02-08,04,pmf,large_decrease,0.04
+2025-01-25,3,wk flu hosp rate change,2025-02-15,04,pmf,stable,0.209
+2025-01-25,3,wk flu hosp rate change,2025-02-15,04,pmf,increase,0.025
+2025-01-25,3,wk flu hosp rate change,2025-02-15,04,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,04,pmf,decrease,0.728
+2025-01-25,3,wk flu hosp rate change,2025-02-15,04,pmf,large_decrease,0.038
+2025-01-25,0,wk flu hosp rate change,2025-01-25,05,pmf,stable,0.402
+2025-01-25,0,wk flu hosp rate change,2025-01-25,05,pmf,increase,0.377
+2025-01-25,0,wk flu hosp rate change,2025-01-25,05,pmf,large_increase,0.006
+2025-01-25,0,wk flu hosp rate change,2025-01-25,05,pmf,decrease,0.214
+2025-01-25,0,wk flu hosp rate change,2025-01-25,05,pmf,large_decrease,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,05,pmf,stable,0.363
+2025-01-25,1,wk flu hosp rate change,2025-02-01,05,pmf,increase,0.484
+2025-01-25,1,wk flu hosp rate change,2025-02-01,05,pmf,large_increase,0.003
+2025-01-25,1,wk flu hosp rate change,2025-02-01,05,pmf,decrease,0.15
+2025-01-25,1,wk flu hosp rate change,2025-02-01,05,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,05,pmf,stable,0.408
+2025-01-25,2,wk flu hosp rate change,2025-02-08,05,pmf,increase,0.427
+2025-01-25,2,wk flu hosp rate change,2025-02-08,05,pmf,large_increase,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,05,pmf,decrease,0.163
+2025-01-25,2,wk flu hosp rate change,2025-02-08,05,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,05,pmf,stable,0.477
+2025-01-25,3,wk flu hosp rate change,2025-02-15,05,pmf,increase,0.399
+2025-01-25,3,wk flu hosp rate change,2025-02-15,05,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,05,pmf,decrease,0.123
+2025-01-25,3,wk flu hosp rate change,2025-02-15,05,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,06,pmf,stable,0.123
+2025-01-25,0,wk flu hosp rate change,2025-01-25,06,pmf,increase,0.272
+2025-01-25,0,wk flu hosp rate change,2025-01-25,06,pmf,large_increase,0.242
+2025-01-25,0,wk flu hosp rate change,2025-01-25,06,pmf,decrease,0.224
+2025-01-25,0,wk flu hosp rate change,2025-01-25,06,pmf,large_decrease,0.139
+2025-01-25,1,wk flu hosp rate change,2025-02-01,06,pmf,stable,0.142
+2025-01-25,1,wk flu hosp rate change,2025-02-01,06,pmf,increase,0.317
+2025-01-25,1,wk flu hosp rate change,2025-02-01,06,pmf,large_increase,0.182
+2025-01-25,1,wk flu hosp rate change,2025-02-01,06,pmf,decrease,0.257
+2025-01-25,1,wk flu hosp rate change,2025-02-01,06,pmf,large_decrease,0.102
+2025-01-25,2,wk flu hosp rate change,2025-02-08,06,pmf,stable,0.159
+2025-01-25,2,wk flu hosp rate change,2025-02-08,06,pmf,increase,0.317
+2025-01-25,2,wk flu hosp rate change,2025-02-08,06,pmf,large_increase,0.149
+2025-01-25,2,wk flu hosp rate change,2025-02-08,06,pmf,decrease,0.273
+2025-01-25,2,wk flu hosp rate change,2025-02-08,06,pmf,large_decrease,0.102
+2025-01-25,3,wk flu hosp rate change,2025-02-15,06,pmf,stable,0.193
+2025-01-25,3,wk flu hosp rate change,2025-02-15,06,pmf,increase,0.311
+2025-01-25,3,wk flu hosp rate change,2025-02-15,06,pmf,large_increase,0.129
+2025-01-25,3,wk flu hosp rate change,2025-02-15,06,pmf,decrease,0.273
+2025-01-25,3,wk flu hosp rate change,2025-02-15,06,pmf,large_decrease,0.094
+2025-01-25,0,wk flu hosp rate change,2025-01-25,08,pmf,stable,0.074
+2025-01-25,0,wk flu hosp rate change,2025-01-25,08,pmf,increase,0.004
+2025-01-25,0,wk flu hosp rate change,2025-01-25,08,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,08,pmf,decrease,0.855
+2025-01-25,0,wk flu hosp rate change,2025-01-25,08,pmf,large_decrease,0.067
+2025-01-25,1,wk flu hosp rate change,2025-02-01,08,pmf,stable,0.064
+2025-01-25,1,wk flu hosp rate change,2025-02-01,08,pmf,increase,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,08,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,08,pmf,decrease,0.893
+2025-01-25,1,wk flu hosp rate change,2025-02-01,08,pmf,large_decrease,0.041
+2025-01-25,2,wk flu hosp rate change,2025-02-08,08,pmf,stable,0.064
+2025-01-25,2,wk flu hosp rate change,2025-02-08,08,pmf,increase,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,08,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,08,pmf,decrease,0.896
+2025-01-25,2,wk flu hosp rate change,2025-02-08,08,pmf,large_decrease,0.038
+2025-01-25,3,wk flu hosp rate change,2025-02-15,08,pmf,stable,0.092
+2025-01-25,3,wk flu hosp rate change,2025-02-15,08,pmf,increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,08,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,08,pmf,decrease,0.884
+2025-01-25,3,wk flu hosp rate change,2025-02-15,08,pmf,large_decrease,0.023
+2025-01-25,0,wk flu hosp rate change,2025-01-25,09,pmf,stable,0.313
+2025-01-25,0,wk flu hosp rate change,2025-01-25,09,pmf,increase,0.429
+2025-01-25,0,wk flu hosp rate change,2025-01-25,09,pmf,large_increase,0.021
+2025-01-25,0,wk flu hosp rate change,2025-01-25,09,pmf,decrease,0.233
+2025-01-25,0,wk flu hosp rate change,2025-01-25,09,pmf,large_decrease,0.004
+2025-01-25,1,wk flu hosp rate change,2025-02-01,09,pmf,stable,0.32
+2025-01-25,1,wk flu hosp rate change,2025-02-01,09,pmf,increase,0.469
+2025-01-25,1,wk flu hosp rate change,2025-02-01,09,pmf,large_increase,0.011
+2025-01-25,1,wk flu hosp rate change,2025-02-01,09,pmf,decrease,0.199
+2025-01-25,1,wk flu hosp rate change,2025-02-01,09,pmf,large_decrease,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,09,pmf,stable,0.338
+2025-01-25,2,wk flu hosp rate change,2025-02-08,09,pmf,increase,0.448
+2025-01-25,2,wk flu hosp rate change,2025-02-08,09,pmf,large_increase,0.009
+2025-01-25,2,wk flu hosp rate change,2025-02-08,09,pmf,decrease,0.204
+2025-01-25,2,wk flu hosp rate change,2025-02-08,09,pmf,large_decrease,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,09,pmf,stable,0.397
+2025-01-25,3,wk flu hosp rate change,2025-02-15,09,pmf,increase,0.417
+2025-01-25,3,wk flu hosp rate change,2025-02-15,09,pmf,large_increase,0.008
+2025-01-25,3,wk flu hosp rate change,2025-02-15,09,pmf,decrease,0.177
+2025-01-25,3,wk flu hosp rate change,2025-02-15,09,pmf,large_decrease,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,10,pmf,stable,0.619
+2025-01-25,0,wk flu hosp rate change,2025-01-25,10,pmf,increase,0.099
+2025-01-25,0,wk flu hosp rate change,2025-01-25,10,pmf,large_increase,0.032
+2025-01-25,0,wk flu hosp rate change,2025-01-25,10,pmf,decrease,0.18
+2025-01-25,0,wk flu hosp rate change,2025-01-25,10,pmf,large_decrease,0.07
+2025-01-25,1,wk flu hosp rate change,2025-02-01,10,pmf,stable,0.5
+2025-01-25,1,wk flu hosp rate change,2025-02-01,10,pmf,increase,0.12
+2025-01-25,1,wk flu hosp rate change,2025-02-01,10,pmf,large_increase,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,10,pmf,decrease,0.353
+2025-01-25,1,wk flu hosp rate change,2025-02-01,10,pmf,large_decrease,0.025
+2025-01-25,2,wk flu hosp rate change,2025-02-08,10,pmf,stable,0.412
+2025-01-25,2,wk flu hosp rate change,2025-02-08,10,pmf,increase,0.088
+2025-01-25,2,wk flu hosp rate change,2025-02-08,10,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,10,pmf,decrease,0.482
+2025-01-25,2,wk flu hosp rate change,2025-02-08,10,pmf,large_decrease,0.018
+2025-01-25,3,wk flu hosp rate change,2025-02-15,10,pmf,stable,0.375
+2025-01-25,3,wk flu hosp rate change,2025-02-15,10,pmf,increase,0.1
+2025-01-25,3,wk flu hosp rate change,2025-02-15,10,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,10,pmf,decrease,0.521
+2025-01-25,3,wk flu hosp rate change,2025-02-15,10,pmf,large_decrease,0.004
+2025-01-25,0,wk flu hosp rate change,2025-01-25,12,pmf,stable,0.136
+2025-01-25,0,wk flu hosp rate change,2025-01-25,12,pmf,increase,0.287
+2025-01-25,0,wk flu hosp rate change,2025-01-25,12,pmf,large_increase,0.205
+2025-01-25,0,wk flu hosp rate change,2025-01-25,12,pmf,decrease,0.243
+2025-01-25,0,wk flu hosp rate change,2025-01-25,12,pmf,large_decrease,0.129
+2025-01-25,1,wk flu hosp rate change,2025-02-01,12,pmf,stable,0.156
+2025-01-25,1,wk flu hosp rate change,2025-02-01,12,pmf,increase,0.348
+2025-01-25,1,wk flu hosp rate change,2025-02-01,12,pmf,large_increase,0.162
+2025-01-25,1,wk flu hosp rate change,2025-02-01,12,pmf,decrease,0.259
+2025-01-25,1,wk flu hosp rate change,2025-02-01,12,pmf,large_decrease,0.075
+2025-01-25,2,wk flu hosp rate change,2025-02-08,12,pmf,stable,0.17
+2025-01-25,2,wk flu hosp rate change,2025-02-08,12,pmf,increase,0.349
+2025-01-25,2,wk flu hosp rate change,2025-02-08,12,pmf,large_increase,0.15
+2025-01-25,2,wk flu hosp rate change,2025-02-08,12,pmf,decrease,0.26
+2025-01-25,2,wk flu hosp rate change,2025-02-08,12,pmf,large_decrease,0.071
+2025-01-25,3,wk flu hosp rate change,2025-02-15,12,pmf,stable,0.198
+2025-01-25,3,wk flu hosp rate change,2025-02-15,12,pmf,increase,0.34
+2025-01-25,3,wk flu hosp rate change,2025-02-15,12,pmf,large_increase,0.142
+2025-01-25,3,wk flu hosp rate change,2025-02-15,12,pmf,decrease,0.252
+2025-01-25,3,wk flu hosp rate change,2025-02-15,12,pmf,large_decrease,0.068
+2025-01-25,0,wk flu hosp rate change,2025-01-25,13,pmf,stable,0.431
+2025-01-25,0,wk flu hosp rate change,2025-01-25,13,pmf,increase,0.5
+2025-01-25,0,wk flu hosp rate change,2025-01-25,13,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,13,pmf,decrease,0.069
+2025-01-25,0,wk flu hosp rate change,2025-01-25,13,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,13,pmf,stable,0.438
+2025-01-25,1,wk flu hosp rate change,2025-02-01,13,pmf,increase,0.506
+2025-01-25,1,wk flu hosp rate change,2025-02-01,13,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,13,pmf,decrease,0.056
+2025-01-25,1,wk flu hosp rate change,2025-02-01,13,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,13,pmf,stable,0.498
+2025-01-25,2,wk flu hosp rate change,2025-02-08,13,pmf,increase,0.438
+2025-01-25,2,wk flu hosp rate change,2025-02-08,13,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,13,pmf,decrease,0.064
+2025-01-25,2,wk flu hosp rate change,2025-02-08,13,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,13,pmf,stable,0.58
+2025-01-25,3,wk flu hosp rate change,2025-02-15,13,pmf,increase,0.371
+2025-01-25,3,wk flu hosp rate change,2025-02-15,13,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,13,pmf,decrease,0.049
+2025-01-25,3,wk flu hosp rate change,2025-02-15,13,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,15,pmf,stable,0.629
+2025-01-25,0,wk flu hosp rate change,2025-01-25,15,pmf,increase,0.068
+2025-01-25,0,wk flu hosp rate change,2025-01-25,15,pmf,large_increase,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,15,pmf,decrease,0.268
+2025-01-25,0,wk flu hosp rate change,2025-01-25,15,pmf,large_decrease,0.032
+2025-01-25,1,wk flu hosp rate change,2025-02-01,15,pmf,stable,0.483
+2025-01-25,1,wk flu hosp rate change,2025-02-01,15,pmf,increase,0.067
+2025-01-25,1,wk flu hosp rate change,2025-02-01,15,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,15,pmf,decrease,0.448
+2025-01-25,1,wk flu hosp rate change,2025-02-01,15,pmf,large_decrease,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,15,pmf,stable,0.35
+2025-01-25,2,wk flu hosp rate change,2025-02-08,15,pmf,increase,0.05
+2025-01-25,2,wk flu hosp rate change,2025-02-08,15,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,15,pmf,decrease,0.599
+2025-01-25,2,wk flu hosp rate change,2025-02-08,15,pmf,large_decrease,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,15,pmf,stable,0.425
+2025-01-25,3,wk flu hosp rate change,2025-02-15,15,pmf,increase,0.025
+2025-01-25,3,wk flu hosp rate change,2025-02-15,15,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,15,pmf,decrease,0.55
+2025-01-25,3,wk flu hosp rate change,2025-02-15,15,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,16,pmf,stable,0.477
+2025-01-25,0,wk flu hosp rate change,2025-01-25,16,pmf,increase,0.121
+2025-01-25,0,wk flu hosp rate change,2025-01-25,16,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,16,pmf,decrease,0.367
+2025-01-25,0,wk flu hosp rate change,2025-01-25,16,pmf,large_decrease,0.033
+2025-01-25,1,wk flu hosp rate change,2025-02-01,16,pmf,stable,0.359
+2025-01-25,1,wk flu hosp rate change,2025-02-01,16,pmf,increase,0.215
+2025-01-25,1,wk flu hosp rate change,2025-02-01,16,pmf,large_increase,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,16,pmf,decrease,0.42
+2025-01-25,1,wk flu hosp rate change,2025-02-01,16,pmf,large_decrease,0.005
+2025-01-25,2,wk flu hosp rate change,2025-02-08,16,pmf,stable,0.385
+2025-01-25,2,wk flu hosp rate change,2025-02-08,16,pmf,increase,0.19
+2025-01-25,2,wk flu hosp rate change,2025-02-08,16,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,16,pmf,decrease,0.422
+2025-01-25,2,wk flu hosp rate change,2025-02-08,16,pmf,large_decrease,0.003
+2025-01-25,3,wk flu hosp rate change,2025-02-15,16,pmf,stable,0.468
+2025-01-25,3,wk flu hosp rate change,2025-02-15,16,pmf,increase,0.157
+2025-01-25,3,wk flu hosp rate change,2025-02-15,16,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,16,pmf,decrease,0.373
+2025-01-25,3,wk flu hosp rate change,2025-02-15,16,pmf,large_decrease,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,17,pmf,stable,0.282
+2025-01-25,0,wk flu hosp rate change,2025-01-25,17,pmf,increase,0.045
+2025-01-25,0,wk flu hosp rate change,2025-01-25,17,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,17,pmf,decrease,0.665
+2025-01-25,0,wk flu hosp rate change,2025-01-25,17,pmf,large_decrease,0.008
+2025-01-25,1,wk flu hosp rate change,2025-02-01,17,pmf,stable,0.232
+2025-01-25,1,wk flu hosp rate change,2025-02-01,17,pmf,increase,0.018
+2025-01-25,1,wk flu hosp rate change,2025-02-01,17,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,17,pmf,decrease,0.748
+2025-01-25,1,wk flu hosp rate change,2025-02-01,17,pmf,large_decrease,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,17,pmf,stable,0.184
+2025-01-25,2,wk flu hosp rate change,2025-02-08,17,pmf,increase,0.006
+2025-01-25,2,wk flu hosp rate change,2025-02-08,17,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,17,pmf,decrease,0.808
+2025-01-25,2,wk flu hosp rate change,2025-02-08,17,pmf,large_decrease,0.002
+2025-01-25,3,wk flu hosp rate change,2025-02-15,17,pmf,stable,0.202
+2025-01-25,3,wk flu hosp rate change,2025-02-15,17,pmf,increase,0.002
+2025-01-25,3,wk flu hosp rate change,2025-02-15,17,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,17,pmf,decrease,0.795
+2025-01-25,3,wk flu hosp rate change,2025-02-15,17,pmf,large_decrease,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,18,pmf,stable,0.481
+2025-01-25,0,wk flu hosp rate change,2025-01-25,18,pmf,increase,0.269
+2025-01-25,0,wk flu hosp rate change,2025-01-25,18,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,18,pmf,decrease,0.25
+2025-01-25,0,wk flu hosp rate change,2025-01-25,18,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,18,pmf,stable,0.468
+2025-01-25,1,wk flu hosp rate change,2025-02-01,18,pmf,increase,0.287
+2025-01-25,1,wk flu hosp rate change,2025-02-01,18,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,18,pmf,decrease,0.245
+2025-01-25,1,wk flu hosp rate change,2025-02-01,18,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,18,pmf,stable,0.486
+2025-01-25,2,wk flu hosp rate change,2025-02-08,18,pmf,increase,0.246
+2025-01-25,2,wk flu hosp rate change,2025-02-08,18,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,18,pmf,decrease,0.268
+2025-01-25,2,wk flu hosp rate change,2025-02-08,18,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,18,pmf,stable,0.554
+2025-01-25,3,wk flu hosp rate change,2025-02-15,18,pmf,increase,0.213
+2025-01-25,3,wk flu hosp rate change,2025-02-15,18,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,18,pmf,decrease,0.233
+2025-01-25,3,wk flu hosp rate change,2025-02-15,18,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,19,pmf,stable,0.44
+2025-01-25,0,wk flu hosp rate change,2025-01-25,19,pmf,increase,0.132
+2025-01-25,0,wk flu hosp rate change,2025-01-25,19,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,19,pmf,decrease,0.428
+2025-01-25,0,wk flu hosp rate change,2025-01-25,19,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,19,pmf,stable,0.452
+2025-01-25,1,wk flu hosp rate change,2025-02-01,19,pmf,increase,0.115
+2025-01-25,1,wk flu hosp rate change,2025-02-01,19,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,19,pmf,decrease,0.433
+2025-01-25,1,wk flu hosp rate change,2025-02-01,19,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,19,pmf,stable,0.442
+2025-01-25,2,wk flu hosp rate change,2025-02-08,19,pmf,increase,0.084
+2025-01-25,2,wk flu hosp rate change,2025-02-08,19,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,19,pmf,decrease,0.474
+2025-01-25,2,wk flu hosp rate change,2025-02-08,19,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,19,pmf,stable,0.521
+2025-01-25,3,wk flu hosp rate change,2025-02-15,19,pmf,increase,0.06
+2025-01-25,3,wk flu hosp rate change,2025-02-15,19,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,19,pmf,decrease,0.419
+2025-01-25,3,wk flu hosp rate change,2025-02-15,19,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,20,pmf,stable,0.525
+2025-01-25,0,wk flu hosp rate change,2025-01-25,20,pmf,increase,0.2
+2025-01-25,0,wk flu hosp rate change,2025-01-25,20,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,20,pmf,decrease,0.275
+2025-01-25,0,wk flu hosp rate change,2025-01-25,20,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,20,pmf,stable,0.531
+2025-01-25,1,wk flu hosp rate change,2025-02-01,20,pmf,increase,0.233
+2025-01-25,1,wk flu hosp rate change,2025-02-01,20,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,20,pmf,decrease,0.236
+2025-01-25,1,wk flu hosp rate change,2025-02-01,20,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,20,pmf,stable,0.587
+2025-01-25,2,wk flu hosp rate change,2025-02-08,20,pmf,increase,0.189
+2025-01-25,2,wk flu hosp rate change,2025-02-08,20,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,20,pmf,decrease,0.224
+2025-01-25,2,wk flu hosp rate change,2025-02-08,20,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,20,pmf,stable,0.671
+2025-01-25,3,wk flu hosp rate change,2025-02-15,20,pmf,increase,0.15
+2025-01-25,3,wk flu hosp rate change,2025-02-15,20,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,20,pmf,decrease,0.179
+2025-01-25,3,wk flu hosp rate change,2025-02-15,20,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,21,pmf,stable,0.376
+2025-01-25,0,wk flu hosp rate change,2025-01-25,21,pmf,increase,0.32
+2025-01-25,0,wk flu hosp rate change,2025-01-25,21,pmf,large_increase,0.004
+2025-01-25,0,wk flu hosp rate change,2025-01-25,21,pmf,decrease,0.297
+2025-01-25,0,wk flu hosp rate change,2025-01-25,21,pmf,large_decrease,0.003
+2025-01-25,1,wk flu hosp rate change,2025-02-01,21,pmf,stable,0.379
+2025-01-25,1,wk flu hosp rate change,2025-02-01,21,pmf,increase,0.355
+2025-01-25,1,wk flu hosp rate change,2025-02-01,21,pmf,large_increase,0.003
+2025-01-25,1,wk flu hosp rate change,2025-02-01,21,pmf,decrease,0.262
+2025-01-25,1,wk flu hosp rate change,2025-02-01,21,pmf,large_decrease,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,21,pmf,stable,0.4
+2025-01-25,2,wk flu hosp rate change,2025-02-08,21,pmf,increase,0.315
+2025-01-25,2,wk flu hosp rate change,2025-02-08,21,pmf,large_increase,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,21,pmf,decrease,0.282
+2025-01-25,2,wk flu hosp rate change,2025-02-08,21,pmf,large_decrease,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,21,pmf,stable,0.468
+2025-01-25,3,wk flu hosp rate change,2025-02-15,21,pmf,increase,0.263
+2025-01-25,3,wk flu hosp rate change,2025-02-15,21,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,21,pmf,decrease,0.267
+2025-01-25,3,wk flu hosp rate change,2025-02-15,21,pmf,large_decrease,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,22,pmf,stable,0.301
+2025-01-25,0,wk flu hosp rate change,2025-01-25,22,pmf,increase,0.398
+2025-01-25,0,wk flu hosp rate change,2025-01-25,22,pmf,large_increase,0.022
+2025-01-25,0,wk flu hosp rate change,2025-01-25,22,pmf,decrease,0.271
+2025-01-25,0,wk flu hosp rate change,2025-01-25,22,pmf,large_decrease,0.008
+2025-01-25,1,wk flu hosp rate change,2025-02-01,22,pmf,stable,0.351
+2025-01-25,1,wk flu hosp rate change,2025-02-01,22,pmf,increase,0.387
+2025-01-25,1,wk flu hosp rate change,2025-02-01,22,pmf,large_increase,0.005
+2025-01-25,1,wk flu hosp rate change,2025-02-01,22,pmf,decrease,0.255
+2025-01-25,1,wk flu hosp rate change,2025-02-01,22,pmf,large_decrease,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,22,pmf,stable,0.411
+2025-01-25,2,wk flu hosp rate change,2025-02-08,22,pmf,increase,0.305
+2025-01-25,2,wk flu hosp rate change,2025-02-08,22,pmf,large_increase,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,22,pmf,decrease,0.282
+2025-01-25,2,wk flu hosp rate change,2025-02-08,22,pmf,large_decrease,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,22,pmf,stable,0.499
+2025-01-25,3,wk flu hosp rate change,2025-02-15,22,pmf,increase,0.269
+2025-01-25,3,wk flu hosp rate change,2025-02-15,22,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,22,pmf,decrease,0.231
+2025-01-25,3,wk flu hosp rate change,2025-02-15,22,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,23,pmf,stable,0.607
+2025-01-25,0,wk flu hosp rate change,2025-01-25,23,pmf,increase,0.109
+2025-01-25,0,wk flu hosp rate change,2025-01-25,23,pmf,large_increase,0.006
+2025-01-25,0,wk flu hosp rate change,2025-01-25,23,pmf,decrease,0.248
+2025-01-25,0,wk flu hosp rate change,2025-01-25,23,pmf,large_decrease,0.03
+2025-01-25,1,wk flu hosp rate change,2025-02-01,23,pmf,stable,0.475
+2025-01-25,1,wk flu hosp rate change,2025-02-01,23,pmf,increase,0.149
+2025-01-25,1,wk flu hosp rate change,2025-02-01,23,pmf,large_increase,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,23,pmf,decrease,0.368
+2025-01-25,1,wk flu hosp rate change,2025-02-01,23,pmf,large_decrease,0.007
+2025-01-25,2,wk flu hosp rate change,2025-02-08,23,pmf,stable,0.387
+2025-01-25,2,wk flu hosp rate change,2025-02-08,23,pmf,increase,0.138
+2025-01-25,2,wk flu hosp rate change,2025-02-08,23,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,23,pmf,decrease,0.471
+2025-01-25,2,wk flu hosp rate change,2025-02-08,23,pmf,large_decrease,0.004
+2025-01-25,3,wk flu hosp rate change,2025-02-15,23,pmf,stable,0.45
+2025-01-25,3,wk flu hosp rate change,2025-02-15,23,pmf,increase,0.1
+2025-01-25,3,wk flu hosp rate change,2025-02-15,23,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,23,pmf,decrease,0.449
+2025-01-25,3,wk flu hosp rate change,2025-02-15,23,pmf,large_decrease,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,24,pmf,stable,0.391
+2025-01-25,0,wk flu hosp rate change,2025-01-25,24,pmf,increase,0.525
+2025-01-25,0,wk flu hosp rate change,2025-01-25,24,pmf,large_increase,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,24,pmf,decrease,0.083
+2025-01-25,0,wk flu hosp rate change,2025-01-25,24,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,24,pmf,stable,0.453
+2025-01-25,1,wk flu hosp rate change,2025-02-01,24,pmf,increase,0.417
+2025-01-25,1,wk flu hosp rate change,2025-02-01,24,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,24,pmf,decrease,0.13
+2025-01-25,1,wk flu hosp rate change,2025-02-01,24,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,24,pmf,stable,0.511
+2025-01-25,2,wk flu hosp rate change,2025-02-08,24,pmf,increase,0.289
+2025-01-25,2,wk flu hosp rate change,2025-02-08,24,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,24,pmf,decrease,0.2
+2025-01-25,2,wk flu hosp rate change,2025-02-08,24,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,24,pmf,stable,0.596
+2025-01-25,3,wk flu hosp rate change,2025-02-15,24,pmf,increase,0.192
+2025-01-25,3,wk flu hosp rate change,2025-02-15,24,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,24,pmf,decrease,0.212
+2025-01-25,3,wk flu hosp rate change,2025-02-15,24,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,25,pmf,stable,0.081
+2025-01-25,0,wk flu hosp rate change,2025-01-25,25,pmf,increase,0.893
+2025-01-25,0,wk flu hosp rate change,2025-01-25,25,pmf,large_increase,0.023
+2025-01-25,0,wk flu hosp rate change,2025-01-25,25,pmf,decrease,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,25,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,25,pmf,stable,0.073
+2025-01-25,1,wk flu hosp rate change,2025-02-01,25,pmf,increase,0.906
+2025-01-25,1,wk flu hosp rate change,2025-02-01,25,pmf,large_increase,0.019
+2025-01-25,1,wk flu hosp rate change,2025-02-01,25,pmf,decrease,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,25,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,25,pmf,stable,0.104
+2025-01-25,2,wk flu hosp rate change,2025-02-08,25,pmf,increase,0.876
+2025-01-25,2,wk flu hosp rate change,2025-02-08,25,pmf,large_increase,0.016
+2025-01-25,2,wk flu hosp rate change,2025-02-08,25,pmf,decrease,0.004
+2025-01-25,2,wk flu hosp rate change,2025-02-08,25,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,25,pmf,stable,0.156
+2025-01-25,3,wk flu hosp rate change,2025-02-15,25,pmf,increase,0.827
+2025-01-25,3,wk flu hosp rate change,2025-02-15,25,pmf,large_increase,0.012
+2025-01-25,3,wk flu hosp rate change,2025-02-15,25,pmf,decrease,0.005
+2025-01-25,3,wk flu hosp rate change,2025-02-15,25,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,26,pmf,stable,0.388
+2025-01-25,0,wk flu hosp rate change,2025-01-25,26,pmf,increase,0.403
+2025-01-25,0,wk flu hosp rate change,2025-01-25,26,pmf,large_increase,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,26,pmf,decrease,0.205
+2025-01-25,0,wk flu hosp rate change,2025-01-25,26,pmf,large_decrease,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,26,pmf,stable,0.389
+2025-01-25,1,wk flu hosp rate change,2025-02-01,26,pmf,increase,0.415
+2025-01-25,1,wk flu hosp rate change,2025-02-01,26,pmf,large_increase,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,26,pmf,decrease,0.194
+2025-01-25,1,wk flu hosp rate change,2025-02-01,26,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,26,pmf,stable,0.417
+2025-01-25,2,wk flu hosp rate change,2025-02-08,26,pmf,increase,0.377
+2025-01-25,2,wk flu hosp rate change,2025-02-08,26,pmf,large_increase,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,26,pmf,decrease,0.204
+2025-01-25,2,wk flu hosp rate change,2025-02-08,26,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,26,pmf,stable,0.478
+2025-01-25,3,wk flu hosp rate change,2025-02-15,26,pmf,increase,0.339
+2025-01-25,3,wk flu hosp rate change,2025-02-15,26,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,26,pmf,decrease,0.182
+2025-01-25,3,wk flu hosp rate change,2025-02-15,26,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,27,pmf,stable,0.351
+2025-01-25,0,wk flu hosp rate change,2025-01-25,27,pmf,increase,0.083
+2025-01-25,0,wk flu hosp rate change,2025-01-25,27,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,27,pmf,decrease,0.562
+2025-01-25,0,wk flu hosp rate change,2025-01-25,27,pmf,large_decrease,0.004
+2025-01-25,1,wk flu hosp rate change,2025-02-01,27,pmf,stable,0.21
+2025-01-25,1,wk flu hosp rate change,2025-02-01,27,pmf,increase,0.033
+2025-01-25,1,wk flu hosp rate change,2025-02-01,27,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,27,pmf,decrease,0.738
+2025-01-25,1,wk flu hosp rate change,2025-02-01,27,pmf,large_decrease,0.019
+2025-01-25,2,wk flu hosp rate change,2025-02-08,27,pmf,stable,0.116
+2025-01-25,2,wk flu hosp rate change,2025-02-08,27,pmf,increase,0.012
+2025-01-25,2,wk flu hosp rate change,2025-02-08,27,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,27,pmf,decrease,0.803
+2025-01-25,2,wk flu hosp rate change,2025-02-08,27,pmf,large_decrease,0.069
+2025-01-25,3,wk flu hosp rate change,2025-02-15,27,pmf,stable,0.094
+2025-01-25,3,wk flu hosp rate change,2025-02-15,27,pmf,increase,0.006
+2025-01-25,3,wk flu hosp rate change,2025-02-15,27,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,27,pmf,decrease,0.792
+2025-01-25,3,wk flu hosp rate change,2025-02-15,27,pmf,large_decrease,0.108
+2025-01-25,0,wk flu hosp rate change,2025-01-25,28,pmf,stable,0.306
+2025-01-25,0,wk flu hosp rate change,2025-01-25,28,pmf,increase,0.174
+2025-01-25,0,wk flu hosp rate change,2025-01-25,28,pmf,large_increase,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,28,pmf,decrease,0.476
+2025-01-25,0,wk flu hosp rate change,2025-01-25,28,pmf,large_decrease,0.041
+2025-01-25,1,wk flu hosp rate change,2025-02-01,28,pmf,stable,0.32
+2025-01-25,1,wk flu hosp rate change,2025-02-01,28,pmf,increase,0.142
+2025-01-25,1,wk flu hosp rate change,2025-02-01,28,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,28,pmf,decrease,0.526
+2025-01-25,1,wk flu hosp rate change,2025-02-01,28,pmf,large_decrease,0.012
+2025-01-25,2,wk flu hosp rate change,2025-02-08,28,pmf,stable,0.334
+2025-01-25,2,wk flu hosp rate change,2025-02-08,28,pmf,increase,0.091
+2025-01-25,2,wk flu hosp rate change,2025-02-08,28,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,28,pmf,decrease,0.568
+2025-01-25,2,wk flu hosp rate change,2025-02-08,28,pmf,large_decrease,0.007
+2025-01-25,3,wk flu hosp rate change,2025-02-15,28,pmf,stable,0.396
+2025-01-25,3,wk flu hosp rate change,2025-02-15,28,pmf,increase,0.064
+2025-01-25,3,wk flu hosp rate change,2025-02-15,28,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,28,pmf,decrease,0.537
+2025-01-25,3,wk flu hosp rate change,2025-02-15,28,pmf,large_decrease,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,29,pmf,stable,0.154
+2025-01-25,0,wk flu hosp rate change,2025-01-25,29,pmf,increase,0.023
+2025-01-25,0,wk flu hosp rate change,2025-01-25,29,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,29,pmf,decrease,0.756
+2025-01-25,0,wk flu hosp rate change,2025-01-25,29,pmf,large_decrease,0.067
+2025-01-25,1,wk flu hosp rate change,2025-02-01,29,pmf,stable,0.181
+2025-01-25,1,wk flu hosp rate change,2025-02-01,29,pmf,increase,0.033
+2025-01-25,1,wk flu hosp rate change,2025-02-01,29,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,29,pmf,decrease,0.755
+2025-01-25,1,wk flu hosp rate change,2025-02-01,29,pmf,large_decrease,0.031
+2025-01-25,2,wk flu hosp rate change,2025-02-08,29,pmf,stable,0.206
+2025-01-25,2,wk flu hosp rate change,2025-02-08,29,pmf,increase,0.036
+2025-01-25,2,wk flu hosp rate change,2025-02-08,29,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,29,pmf,decrease,0.729
+2025-01-25,2,wk flu hosp rate change,2025-02-08,29,pmf,large_decrease,0.029
+2025-01-25,3,wk flu hosp rate change,2025-02-15,29,pmf,stable,0.27
+2025-01-25,3,wk flu hosp rate change,2025-02-15,29,pmf,increase,0.037
+2025-01-25,3,wk flu hosp rate change,2025-02-15,29,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,29,pmf,decrease,0.672
+2025-01-25,3,wk flu hosp rate change,2025-02-15,29,pmf,large_decrease,0.021
+2025-01-25,0,wk flu hosp rate change,2025-01-25,30,pmf,stable,0.426
+2025-01-25,0,wk flu hosp rate change,2025-01-25,30,pmf,increase,0.109
+2025-01-25,0,wk flu hosp rate change,2025-01-25,30,pmf,large_increase,0.091
+2025-01-25,0,wk flu hosp rate change,2025-01-25,30,pmf,decrease,0.174
+2025-01-25,0,wk flu hosp rate change,2025-01-25,30,pmf,large_decrease,0.2
+2025-01-25,1,wk flu hosp rate change,2025-02-01,30,pmf,stable,0.304
+2025-01-25,1,wk flu hosp rate change,2025-02-01,30,pmf,increase,0.179
+2025-01-25,1,wk flu hosp rate change,2025-02-01,30,pmf,large_increase,0.034
+2025-01-25,1,wk flu hosp rate change,2025-02-01,30,pmf,decrease,0.333
+2025-01-25,1,wk flu hosp rate change,2025-02-01,30,pmf,large_decrease,0.15
+2025-01-25,2,wk flu hosp rate change,2025-02-08,30,pmf,stable,0.25
+2025-01-25,2,wk flu hosp rate change,2025-02-08,30,pmf,increase,0.182
+2025-01-25,2,wk flu hosp rate change,2025-02-08,30,pmf,large_increase,0.018
+2025-01-25,2,wk flu hosp rate change,2025-02-08,30,pmf,decrease,0.417
+2025-01-25,2,wk flu hosp rate change,2025-02-08,30,pmf,large_decrease,0.133
+2025-01-25,3,wk flu hosp rate change,2025-02-15,30,pmf,stable,0.242
+2025-01-25,3,wk flu hosp rate change,2025-02-15,30,pmf,increase,0.174
+2025-01-25,3,wk flu hosp rate change,2025-02-15,30,pmf,large_increase,0.008
+2025-01-25,3,wk flu hosp rate change,2025-02-15,30,pmf,decrease,0.481
+2025-01-25,3,wk flu hosp rate change,2025-02-15,30,pmf,large_decrease,0.095
+2025-01-25,0,wk flu hosp rate change,2025-01-25,31,pmf,stable,0.65
+2025-01-25,0,wk flu hosp rate change,2025-01-25,31,pmf,increase,0.198
+2025-01-25,0,wk flu hosp rate change,2025-01-25,31,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,31,pmf,decrease,0.149
+2025-01-25,0,wk flu hosp rate change,2025-01-25,31,pmf,large_decrease,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,31,pmf,stable,0.467
+2025-01-25,1,wk flu hosp rate change,2025-02-01,31,pmf,increase,0.317
+2025-01-25,1,wk flu hosp rate change,2025-02-01,31,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,31,pmf,decrease,0.216
+2025-01-25,1,wk flu hosp rate change,2025-02-01,31,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,31,pmf,stable,0.534
+2025-01-25,2,wk flu hosp rate change,2025-02-08,31,pmf,increase,0.25
+2025-01-25,2,wk flu hosp rate change,2025-02-08,31,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,31,pmf,decrease,0.216
+2025-01-25,2,wk flu hosp rate change,2025-02-08,31,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,31,pmf,stable,0.632
+2025-01-25,3,wk flu hosp rate change,2025-02-15,31,pmf,increase,0.2
+2025-01-25,3,wk flu hosp rate change,2025-02-15,31,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,31,pmf,decrease,0.168
+2025-01-25,3,wk flu hosp rate change,2025-02-15,31,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,32,pmf,stable,0.21
+2025-01-25,0,wk flu hosp rate change,2025-01-25,32,pmf,increase,0.04
+2025-01-25,0,wk flu hosp rate change,2025-01-25,32,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,32,pmf,decrease,0.7
+2025-01-25,0,wk flu hosp rate change,2025-01-25,32,pmf,large_decrease,0.05
+2025-01-25,1,wk flu hosp rate change,2025-02-01,32,pmf,stable,0.216
+2025-01-25,1,wk flu hosp rate change,2025-02-01,32,pmf,increase,0.034
+2025-01-25,1,wk flu hosp rate change,2025-02-01,32,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,32,pmf,decrease,0.733
+2025-01-25,1,wk flu hosp rate change,2025-02-01,32,pmf,large_decrease,0.017
+2025-01-25,2,wk flu hosp rate change,2025-02-08,32,pmf,stable,0.207
+2025-01-25,2,wk flu hosp rate change,2025-02-08,32,pmf,increase,0.025
+2025-01-25,2,wk flu hosp rate change,2025-02-08,32,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,32,pmf,decrease,0.755
+2025-01-25,2,wk flu hosp rate change,2025-02-08,32,pmf,large_decrease,0.013
+2025-01-25,3,wk flu hosp rate change,2025-02-15,32,pmf,stable,0.281
+2025-01-25,3,wk flu hosp rate change,2025-02-15,32,pmf,increase,0.019
+2025-01-25,3,wk flu hosp rate change,2025-02-15,32,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,32,pmf,decrease,0.695
+2025-01-25,3,wk flu hosp rate change,2025-02-15,32,pmf,large_decrease,0.005
+2025-01-25,0,wk flu hosp rate change,2025-01-25,33,pmf,stable,0.635
+2025-01-25,0,wk flu hosp rate change,2025-01-25,33,pmf,increase,0.063
+2025-01-25,0,wk flu hosp rate change,2025-01-25,33,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,33,pmf,decrease,0.275
+2025-01-25,0,wk flu hosp rate change,2025-01-25,33,pmf,large_decrease,0.025
+2025-01-25,1,wk flu hosp rate change,2025-02-01,33,pmf,stable,0.473
+2025-01-25,1,wk flu hosp rate change,2025-02-01,33,pmf,increase,0.077
+2025-01-25,1,wk flu hosp rate change,2025-02-01,33,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,33,pmf,decrease,0.446
+2025-01-25,1,wk flu hosp rate change,2025-02-01,33,pmf,large_decrease,0.004
+2025-01-25,2,wk flu hosp rate change,2025-02-08,33,pmf,stable,0.382
+2025-01-25,2,wk flu hosp rate change,2025-02-08,33,pmf,increase,0.068
+2025-01-25,2,wk flu hosp rate change,2025-02-08,33,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,33,pmf,decrease,0.549
+2025-01-25,2,wk flu hosp rate change,2025-02-08,33,pmf,large_decrease,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,33,pmf,stable,0.456
+2025-01-25,3,wk flu hosp rate change,2025-02-15,33,pmf,increase,0.044
+2025-01-25,3,wk flu hosp rate change,2025-02-15,33,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,33,pmf,decrease,0.5
+2025-01-25,3,wk flu hosp rate change,2025-02-15,33,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,34,pmf,stable,0.406
+2025-01-25,0,wk flu hosp rate change,2025-01-25,34,pmf,increase,0.312
+2025-01-25,0,wk flu hosp rate change,2025-01-25,34,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,34,pmf,decrease,0.279
+2025-01-25,0,wk flu hosp rate change,2025-01-25,34,pmf,large_decrease,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,34,pmf,stable,0.405
+2025-01-25,1,wk flu hosp rate change,2025-02-01,34,pmf,increase,0.459
+2025-01-25,1,wk flu hosp rate change,2025-02-01,34,pmf,large_increase,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,34,pmf,decrease,0.135
+2025-01-25,1,wk flu hosp rate change,2025-02-01,34,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,34,pmf,stable,0.445
+2025-01-25,2,wk flu hosp rate change,2025-02-08,34,pmf,increase,0.422
+2025-01-25,2,wk flu hosp rate change,2025-02-08,34,pmf,large_increase,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,34,pmf,decrease,0.132
+2025-01-25,2,wk flu hosp rate change,2025-02-08,34,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,34,pmf,stable,0.505
+2025-01-25,3,wk flu hosp rate change,2025-02-15,34,pmf,increase,0.403
+2025-01-25,3,wk flu hosp rate change,2025-02-15,34,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,34,pmf,decrease,0.092
+2025-01-25,3,wk flu hosp rate change,2025-02-15,34,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,35,pmf,stable,0.509
+2025-01-25,0,wk flu hosp rate change,2025-01-25,35,pmf,increase,0.164
+2025-01-25,0,wk flu hosp rate change,2025-01-25,35,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,35,pmf,decrease,0.315
+2025-01-25,0,wk flu hosp rate change,2025-01-25,35,pmf,large_decrease,0.01
+2025-01-25,1,wk flu hosp rate change,2025-02-01,35,pmf,stable,0.367
+2025-01-25,1,wk flu hosp rate change,2025-02-01,35,pmf,increase,0.248
+2025-01-25,1,wk flu hosp rate change,2025-02-01,35,pmf,large_increase,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,35,pmf,decrease,0.379
+2025-01-25,1,wk flu hosp rate change,2025-02-01,35,pmf,large_decrease,0.004
+2025-01-25,2,wk flu hosp rate change,2025-02-08,35,pmf,stable,0.373
+2025-01-25,2,wk flu hosp rate change,2025-02-08,35,pmf,increase,0.238
+2025-01-25,2,wk flu hosp rate change,2025-02-08,35,pmf,large_increase,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,35,pmf,decrease,0.382
+2025-01-25,2,wk flu hosp rate change,2025-02-08,35,pmf,large_decrease,0.005
+2025-01-25,3,wk flu hosp rate change,2025-02-15,35,pmf,stable,0.407
+2025-01-25,3,wk flu hosp rate change,2025-02-15,35,pmf,increase,0.232
+2025-01-25,3,wk flu hosp rate change,2025-02-15,35,pmf,large_increase,0.002
+2025-01-25,3,wk flu hosp rate change,2025-02-15,35,pmf,decrease,0.354
+2025-01-25,3,wk flu hosp rate change,2025-02-15,35,pmf,large_decrease,0.005
+2025-01-25,0,wk flu hosp rate change,2025-01-25,36,pmf,stable,0.174
+2025-01-25,0,wk flu hosp rate change,2025-01-25,36,pmf,increase,0.732
+2025-01-25,0,wk flu hosp rate change,2025-01-25,36,pmf,large_increase,0.061
+2025-01-25,0,wk flu hosp rate change,2025-01-25,36,pmf,decrease,0.033
+2025-01-25,0,wk flu hosp rate change,2025-01-25,36,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,36,pmf,stable,0.171
+2025-01-25,1,wk flu hosp rate change,2025-02-01,36,pmf,increase,0.741
+2025-01-25,1,wk flu hosp rate change,2025-02-01,36,pmf,large_increase,0.052
+2025-01-25,1,wk flu hosp rate change,2025-02-01,36,pmf,decrease,0.036
+2025-01-25,1,wk flu hosp rate change,2025-02-01,36,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,36,pmf,stable,0.212
+2025-01-25,2,wk flu hosp rate change,2025-02-08,36,pmf,increase,0.691
+2025-01-25,2,wk flu hosp rate change,2025-02-08,36,pmf,large_increase,0.044
+2025-01-25,2,wk flu hosp rate change,2025-02-08,36,pmf,decrease,0.053
+2025-01-25,2,wk flu hosp rate change,2025-02-08,36,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,36,pmf,stable,0.258
+2025-01-25,3,wk flu hosp rate change,2025-02-15,36,pmf,increase,0.649
+2025-01-25,3,wk flu hosp rate change,2025-02-15,36,pmf,large_increase,0.04
+2025-01-25,3,wk flu hosp rate change,2025-02-15,36,pmf,decrease,0.053
+2025-01-25,3,wk flu hosp rate change,2025-02-15,36,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,37,pmf,stable,0.085
+2025-01-25,0,wk flu hosp rate change,2025-01-25,37,pmf,increase,0.176
+2025-01-25,0,wk flu hosp rate change,2025-01-25,37,pmf,large_increase,0.243
+2025-01-25,0,wk flu hosp rate change,2025-01-25,37,pmf,decrease,0.187
+2025-01-25,0,wk flu hosp rate change,2025-01-25,37,pmf,large_decrease,0.309
+2025-01-25,1,wk flu hosp rate change,2025-02-01,37,pmf,stable,0.108
+2025-01-25,1,wk flu hosp rate change,2025-02-01,37,pmf,increase,0.234
+2025-01-25,1,wk flu hosp rate change,2025-02-01,37,pmf,large_increase,0.196
+2025-01-25,1,wk flu hosp rate change,2025-02-01,37,pmf,decrease,0.243
+2025-01-25,1,wk flu hosp rate change,2025-02-01,37,pmf,large_decrease,0.219
+2025-01-25,2,wk flu hosp rate change,2025-02-08,37,pmf,stable,0.125
+2025-01-25,2,wk flu hosp rate change,2025-02-08,37,pmf,increase,0.247
+2025-01-25,2,wk flu hosp rate change,2025-02-08,37,pmf,large_increase,0.175
+2025-01-25,2,wk flu hosp rate change,2025-02-08,37,pmf,decrease,0.257
+2025-01-25,2,wk flu hosp rate change,2025-02-08,37,pmf,large_decrease,0.196
+2025-01-25,3,wk flu hosp rate change,2025-02-15,37,pmf,stable,0.151
+2025-01-25,3,wk flu hosp rate change,2025-02-15,37,pmf,increase,0.251
+2025-01-25,3,wk flu hosp rate change,2025-02-15,37,pmf,large_increase,0.161
+2025-01-25,3,wk flu hosp rate change,2025-02-15,37,pmf,decrease,0.26
+2025-01-25,3,wk flu hosp rate change,2025-02-15,37,pmf,large_decrease,0.177
+2025-01-25,0,wk flu hosp rate change,2025-01-25,38,pmf,stable,0.441
+2025-01-25,0,wk flu hosp rate change,2025-01-25,38,pmf,increase,0.05
+2025-01-25,0,wk flu hosp rate change,2025-01-25,38,pmf,large_increase,0.183
+2025-01-25,0,wk flu hosp rate change,2025-01-25,38,pmf,decrease,0.076
+2025-01-25,0,wk flu hosp rate change,2025-01-25,38,pmf,large_decrease,0.25
+2025-01-25,1,wk flu hosp rate change,2025-02-01,38,pmf,stable,0.333
+2025-01-25,1,wk flu hosp rate change,2025-02-01,38,pmf,increase,0.15
+2025-01-25,1,wk flu hosp rate change,2025-02-01,38,pmf,large_increase,0.1
+2025-01-25,1,wk flu hosp rate change,2025-02-01,38,pmf,decrease,0.217
+2025-01-25,1,wk flu hosp rate change,2025-02-01,38,pmf,large_decrease,0.2
+2025-01-25,2,wk flu hosp rate change,2025-02-08,38,pmf,stable,0.286
+2025-01-25,2,wk flu hosp rate change,2025-02-08,38,pmf,increase,0.175
+2025-01-25,2,wk flu hosp rate change,2025-02-08,38,pmf,large_increase,0.064
+2025-01-25,2,wk flu hosp rate change,2025-02-08,38,pmf,decrease,0.286
+2025-01-25,2,wk flu hosp rate change,2025-02-08,38,pmf,large_decrease,0.189
+2025-01-25,3,wk flu hosp rate change,2025-02-15,38,pmf,stable,0.261
+2025-01-25,3,wk flu hosp rate change,2025-02-15,38,pmf,increase,0.196
+2025-01-25,3,wk flu hosp rate change,2025-02-15,38,pmf,large_increase,0.043
+2025-01-25,3,wk flu hosp rate change,2025-02-15,38,pmf,decrease,0.35
+2025-01-25,3,wk flu hosp rate change,2025-02-15,38,pmf,large_decrease,0.15
+2025-01-25,0,wk flu hosp rate change,2025-01-25,39,pmf,stable,0.39
+2025-01-25,0,wk flu hosp rate change,2025-01-25,39,pmf,increase,0.505
+2025-01-25,0,wk flu hosp rate change,2025-01-25,39,pmf,large_increase,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,39,pmf,decrease,0.103
+2025-01-25,0,wk flu hosp rate change,2025-01-25,39,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,39,pmf,stable,0.367
+2025-01-25,1,wk flu hosp rate change,2025-02-01,39,pmf,increase,0.558
+2025-01-25,1,wk flu hosp rate change,2025-02-01,39,pmf,large_increase,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,39,pmf,decrease,0.074
+2025-01-25,1,wk flu hosp rate change,2025-02-01,39,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,39,pmf,stable,0.407
+2025-01-25,2,wk flu hosp rate change,2025-02-08,39,pmf,increase,0.509
+2025-01-25,2,wk flu hosp rate change,2025-02-08,39,pmf,large_increase,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,39,pmf,decrease,0.083
+2025-01-25,2,wk flu hosp rate change,2025-02-08,39,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,39,pmf,stable,0.465
+2025-01-25,3,wk flu hosp rate change,2025-02-15,39,pmf,increase,0.465
+2025-01-25,3,wk flu hosp rate change,2025-02-15,39,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,39,pmf,decrease,0.069
+2025-01-25,3,wk flu hosp rate change,2025-02-15,39,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,40,pmf,stable,0.3
+2025-01-25,0,wk flu hosp rate change,2025-01-25,40,pmf,increase,0.43
+2025-01-25,0,wk flu hosp rate change,2025-01-25,40,pmf,large_increase,0.02
+2025-01-25,0,wk flu hosp rate change,2025-01-25,40,pmf,decrease,0.245
+2025-01-25,0,wk flu hosp rate change,2025-01-25,40,pmf,large_decrease,0.005
+2025-01-25,1,wk flu hosp rate change,2025-02-01,40,pmf,stable,0.312
+2025-01-25,1,wk flu hosp rate change,2025-02-01,40,pmf,increase,0.445
+2025-01-25,1,wk flu hosp rate change,2025-02-01,40,pmf,large_increase,0.013
+2025-01-25,1,wk flu hosp rate change,2025-02-01,40,pmf,decrease,0.228
+2025-01-25,1,wk flu hosp rate change,2025-02-01,40,pmf,large_decrease,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,40,pmf,stable,0.333
+2025-01-25,2,wk flu hosp rate change,2025-02-08,40,pmf,increase,0.401
+2025-01-25,2,wk flu hosp rate change,2025-02-08,40,pmf,large_increase,0.011
+2025-01-25,2,wk flu hosp rate change,2025-02-08,40,pmf,decrease,0.252
+2025-01-25,2,wk flu hosp rate change,2025-02-08,40,pmf,large_decrease,0.003
+2025-01-25,3,wk flu hosp rate change,2025-02-15,40,pmf,stable,0.388
+2025-01-25,3,wk flu hosp rate change,2025-02-15,40,pmf,increase,0.376
+2025-01-25,3,wk flu hosp rate change,2025-02-15,40,pmf,large_increase,0.01
+2025-01-25,3,wk flu hosp rate change,2025-02-15,40,pmf,decrease,0.224
+2025-01-25,3,wk flu hosp rate change,2025-02-15,40,pmf,large_decrease,0.002
+2025-01-25,0,wk flu hosp rate change,2025-01-25,41,pmf,stable,0.075
+2025-01-25,0,wk flu hosp rate change,2025-01-25,41,pmf,increase,0.006
+2025-01-25,0,wk flu hosp rate change,2025-01-25,41,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,41,pmf,decrease,0.769
+2025-01-25,0,wk flu hosp rate change,2025-01-25,41,pmf,large_decrease,0.15
+2025-01-25,1,wk flu hosp rate change,2025-02-01,41,pmf,stable,0.057
+2025-01-25,1,wk flu hosp rate change,2025-02-01,41,pmf,increase,0.006
+2025-01-25,1,wk flu hosp rate change,2025-02-01,41,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,41,pmf,decrease,0.749
+2025-01-25,1,wk flu hosp rate change,2025-02-01,41,pmf,large_decrease,0.188
+2025-01-25,2,wk flu hosp rate change,2025-02-08,41,pmf,stable,0.054
+2025-01-25,2,wk flu hosp rate change,2025-02-08,41,pmf,increase,0.006
+2025-01-25,2,wk flu hosp rate change,2025-02-08,41,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,41,pmf,decrease,0.701
+2025-01-25,2,wk flu hosp rate change,2025-02-08,41,pmf,large_decrease,0.239
+2025-01-25,3,wk flu hosp rate change,2025-02-15,41,pmf,stable,0.069
+2025-01-25,3,wk flu hosp rate change,2025-02-15,41,pmf,increase,0.005
+2025-01-25,3,wk flu hosp rate change,2025-02-15,41,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,41,pmf,decrease,0.704
+2025-01-25,3,wk flu hosp rate change,2025-02-15,41,pmf,large_decrease,0.222
+2025-01-25,0,wk flu hosp rate change,2025-01-25,42,pmf,stable,0.066
+2025-01-25,0,wk flu hosp rate change,2025-01-25,42,pmf,increase,0.137
+2025-01-25,0,wk flu hosp rate change,2025-01-25,42,pmf,large_increase,0.235
+2025-01-25,0,wk flu hosp rate change,2025-01-25,42,pmf,decrease,0.156
+2025-01-25,0,wk flu hosp rate change,2025-01-25,42,pmf,large_decrease,0.406
+2025-01-25,1,wk flu hosp rate change,2025-02-01,42,pmf,stable,0.091
+2025-01-25,1,wk flu hosp rate change,2025-02-01,42,pmf,increase,0.207
+2025-01-25,1,wk flu hosp rate change,2025-02-01,42,pmf,large_increase,0.247
+2025-01-25,1,wk flu hosp rate change,2025-02-01,42,pmf,decrease,0.207
+2025-01-25,1,wk flu hosp rate change,2025-02-01,42,pmf,large_decrease,0.248
+2025-01-25,2,wk flu hosp rate change,2025-02-08,42,pmf,stable,0.107
+2025-01-25,2,wk flu hosp rate change,2025-02-08,42,pmf,increase,0.228
+2025-01-25,2,wk flu hosp rate change,2025-02-08,42,pmf,large_increase,0.227
+2025-01-25,2,wk flu hosp rate change,2025-02-08,42,pmf,decrease,0.224
+2025-01-25,2,wk flu hosp rate change,2025-02-08,42,pmf,large_decrease,0.214
+2025-01-25,3,wk flu hosp rate change,2025-02-15,42,pmf,stable,0.135
+2025-01-25,3,wk flu hosp rate change,2025-02-15,42,pmf,increase,0.24
+2025-01-25,3,wk flu hosp rate change,2025-02-15,42,pmf,large_increase,0.217
+2025-01-25,3,wk flu hosp rate change,2025-02-15,42,pmf,decrease,0.226
+2025-01-25,3,wk flu hosp rate change,2025-02-15,42,pmf,large_decrease,0.182
+2025-01-25,0,wk flu hosp rate change,2025-01-25,44,pmf,stable,0.611
+2025-01-25,0,wk flu hosp rate change,2025-01-25,44,pmf,increase,0.035
+2025-01-25,0,wk flu hosp rate change,2025-01-25,44,pmf,large_increase,0.005
+2025-01-25,0,wk flu hosp rate change,2025-01-25,44,pmf,decrease,0.266
+2025-01-25,0,wk flu hosp rate change,2025-01-25,44,pmf,large_decrease,0.083
+2025-01-25,1,wk flu hosp rate change,2025-02-01,44,pmf,stable,0.442
+2025-01-25,1,wk flu hosp rate change,2025-02-01,44,pmf,increase,0.058
+2025-01-25,1,wk flu hosp rate change,2025-02-01,44,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,44,pmf,decrease,0.464
+2025-01-25,1,wk flu hosp rate change,2025-02-01,44,pmf,large_decrease,0.036
+2025-01-25,2,wk flu hosp rate change,2025-02-08,44,pmf,stable,0.325
+2025-01-25,2,wk flu hosp rate change,2025-02-08,44,pmf,increase,0.05
+2025-01-25,2,wk flu hosp rate change,2025-02-08,44,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,44,pmf,decrease,0.596
+2025-01-25,2,wk flu hosp rate change,2025-02-08,44,pmf,large_decrease,0.029
+2025-01-25,3,wk flu hosp rate change,2025-02-15,44,pmf,stable,0.293
+2025-01-25,3,wk flu hosp rate change,2025-02-15,44,pmf,increase,0.039
+2025-01-25,3,wk flu hosp rate change,2025-02-15,44,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,44,pmf,decrease,0.654
+2025-01-25,3,wk flu hosp rate change,2025-02-15,44,pmf,large_decrease,0.014
+2025-01-25,0,wk flu hosp rate change,2025-01-25,45,pmf,stable,0.27
+2025-01-25,0,wk flu hosp rate change,2025-01-25,45,pmf,increase,0.676
+2025-01-25,0,wk flu hosp rate change,2025-01-25,45,pmf,large_increase,0.008
+2025-01-25,0,wk flu hosp rate change,2025-01-25,45,pmf,decrease,0.046
+2025-01-25,0,wk flu hosp rate change,2025-01-25,45,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,45,pmf,stable,0.333
+2025-01-25,1,wk flu hosp rate change,2025-02-01,45,pmf,increase,0.616
+2025-01-25,1,wk flu hosp rate change,2025-02-01,45,pmf,large_increase,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,45,pmf,decrease,0.05
+2025-01-25,1,wk flu hosp rate change,2025-02-01,45,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,45,pmf,stable,0.422
+2025-01-25,2,wk flu hosp rate change,2025-02-08,45,pmf,increase,0.517
+2025-01-25,2,wk flu hosp rate change,2025-02-08,45,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,45,pmf,decrease,0.061
+2025-01-25,2,wk flu hosp rate change,2025-02-08,45,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,45,pmf,stable,0.481
+2025-01-25,3,wk flu hosp rate change,2025-02-15,45,pmf,increase,0.481
+2025-01-25,3,wk flu hosp rate change,2025-02-15,45,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,45,pmf,decrease,0.038
+2025-01-25,3,wk flu hosp rate change,2025-02-15,45,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,46,pmf,stable,0.432
+2025-01-25,0,wk flu hosp rate change,2025-01-25,46,pmf,increase,0.1
+2025-01-25,0,wk flu hosp rate change,2025-01-25,46,pmf,large_increase,0.15
+2025-01-25,0,wk flu hosp rate change,2025-01-25,46,pmf,decrease,0.118
+2025-01-25,0,wk flu hosp rate change,2025-01-25,46,pmf,large_decrease,0.2
+2025-01-25,1,wk flu hosp rate change,2025-02-01,46,pmf,stable,0.334
+2025-01-25,1,wk flu hosp rate change,2025-02-01,46,pmf,increase,0.198
+2025-01-25,1,wk flu hosp rate change,2025-02-01,46,pmf,large_increase,0.085
+2025-01-25,1,wk flu hosp rate change,2025-02-01,46,pmf,decrease,0.252
+2025-01-25,1,wk flu hosp rate change,2025-02-01,46,pmf,large_decrease,0.131
+2025-01-25,2,wk flu hosp rate change,2025-02-08,46,pmf,stable,0.297
+2025-01-25,2,wk flu hosp rate change,2025-02-08,46,pmf,increase,0.233
+2025-01-25,2,wk flu hosp rate change,2025-02-08,46,pmf,large_increase,0.054
+2025-01-25,2,wk flu hosp rate change,2025-02-08,46,pmf,decrease,0.309
+2025-01-25,2,wk flu hosp rate change,2025-02-08,46,pmf,large_decrease,0.107
+2025-01-25,3,wk flu hosp rate change,2025-02-15,46,pmf,stable,0.277
+2025-01-25,3,wk flu hosp rate change,2025-02-15,46,pmf,increase,0.253
+2025-01-25,3,wk flu hosp rate change,2025-02-15,46,pmf,large_increase,0.034
+2025-01-25,3,wk flu hosp rate change,2025-02-15,46,pmf,decrease,0.352
+2025-01-25,3,wk flu hosp rate change,2025-02-15,46,pmf,large_decrease,0.084
+2025-01-25,0,wk flu hosp rate change,2025-01-25,47,pmf,stable,0.117
+2025-01-25,0,wk flu hosp rate change,2025-01-25,47,pmf,increase,0.264
+2025-01-25,0,wk flu hosp rate change,2025-01-25,47,pmf,large_increase,0.252
+2025-01-25,0,wk flu hosp rate change,2025-01-25,47,pmf,decrease,0.22
+2025-01-25,0,wk flu hosp rate change,2025-01-25,47,pmf,large_decrease,0.147
+2025-01-25,1,wk flu hosp rate change,2025-02-01,47,pmf,stable,0.136
+2025-01-25,1,wk flu hosp rate change,2025-02-01,47,pmf,increase,0.316
+2025-01-25,1,wk flu hosp rate change,2025-02-01,47,pmf,large_increase,0.205
+2025-01-25,1,wk flu hosp rate change,2025-02-01,47,pmf,decrease,0.243
+2025-01-25,1,wk flu hosp rate change,2025-02-01,47,pmf,large_decrease,0.1
+2025-01-25,2,wk flu hosp rate change,2025-02-08,47,pmf,stable,0.153
+2025-01-25,2,wk flu hosp rate change,2025-02-08,47,pmf,increase,0.315
+2025-01-25,2,wk flu hosp rate change,2025-02-08,47,pmf,large_increase,0.169
+2025-01-25,2,wk flu hosp rate change,2025-02-08,47,pmf,decrease,0.261
+2025-01-25,2,wk flu hosp rate change,2025-02-08,47,pmf,large_decrease,0.102
+2025-01-25,3,wk flu hosp rate change,2025-02-15,47,pmf,stable,0.184
+2025-01-25,3,wk flu hosp rate change,2025-02-15,47,pmf,increase,0.31
+2025-01-25,3,wk flu hosp rate change,2025-02-15,47,pmf,large_increase,0.149
+2025-01-25,3,wk flu hosp rate change,2025-02-15,47,pmf,decrease,0.261
+2025-01-25,3,wk flu hosp rate change,2025-02-15,47,pmf,large_decrease,0.096
+2025-01-25,0,wk flu hosp rate change,2025-01-25,48,pmf,stable,0.353
+2025-01-25,0,wk flu hosp rate change,2025-01-25,48,pmf,increase,0.263
+2025-01-25,0,wk flu hosp rate change,2025-01-25,48,pmf,large_increase,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,48,pmf,decrease,0.374
+2025-01-25,0,wk flu hosp rate change,2025-01-25,48,pmf,large_decrease,0.007
+2025-01-25,1,wk flu hosp rate change,2025-02-01,48,pmf,stable,0.424
+2025-01-25,1,wk flu hosp rate change,2025-02-01,48,pmf,increase,0.258
+2025-01-25,1,wk flu hosp rate change,2025-02-01,48,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,48,pmf,decrease,0.317
+2025-01-25,1,wk flu hosp rate change,2025-02-01,48,pmf,large_decrease,0.001
+2025-01-25,2,wk flu hosp rate change,2025-02-08,48,pmf,stable,0.477
+2025-01-25,2,wk flu hosp rate change,2025-02-08,48,pmf,increase,0.213
+2025-01-25,2,wk flu hosp rate change,2025-02-08,48,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,48,pmf,decrease,0.31
+2025-01-25,2,wk flu hosp rate change,2025-02-08,48,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,48,pmf,stable,0.574
+2025-01-25,3,wk flu hosp rate change,2025-02-15,48,pmf,increase,0.185
+2025-01-25,3,wk flu hosp rate change,2025-02-15,48,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,48,pmf,decrease,0.241
+2025-01-25,3,wk flu hosp rate change,2025-02-15,48,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,49,pmf,stable,0.27
+2025-01-25,0,wk flu hosp rate change,2025-01-25,49,pmf,increase,0.03
+2025-01-25,0,wk flu hosp rate change,2025-01-25,49,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,49,pmf,decrease,0.696
+2025-01-25,0,wk flu hosp rate change,2025-01-25,49,pmf,large_decrease,0.004
+2025-01-25,1,wk flu hosp rate change,2025-02-01,49,pmf,stable,0.316
+2025-01-25,1,wk flu hosp rate change,2025-02-01,49,pmf,increase,0.034
+2025-01-25,1,wk flu hosp rate change,2025-02-01,49,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,49,pmf,decrease,0.65
+2025-01-25,1,wk flu hosp rate change,2025-02-01,49,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,49,pmf,stable,0.334
+2025-01-25,2,wk flu hosp rate change,2025-02-08,49,pmf,increase,0.029
+2025-01-25,2,wk flu hosp rate change,2025-02-08,49,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,49,pmf,decrease,0.637
+2025-01-25,2,wk flu hosp rate change,2025-02-08,49,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,49,pmf,stable,0.423
+2025-01-25,3,wk flu hosp rate change,2025-02-15,49,pmf,increase,0.027
+2025-01-25,3,wk flu hosp rate change,2025-02-15,49,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,49,pmf,decrease,0.55
+2025-01-25,3,wk flu hosp rate change,2025-02-15,49,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,50,pmf,stable,0.675
+2025-01-25,0,wk flu hosp rate change,2025-01-25,50,pmf,increase,0.025
+2025-01-25,0,wk flu hosp rate change,2025-01-25,50,pmf,large_increase,0.15
+2025-01-25,0,wk flu hosp rate change,2025-01-25,50,pmf,decrease,0.027
+2025-01-25,0,wk flu hosp rate change,2025-01-25,50,pmf,large_decrease,0.123
+2025-01-25,1,wk flu hosp rate change,2025-02-01,50,pmf,stable,0.576
+2025-01-25,1,wk flu hosp rate change,2025-02-01,50,pmf,increase,0.162
+2025-01-25,1,wk flu hosp rate change,2025-02-01,50,pmf,large_increase,0.088
+2025-01-25,1,wk flu hosp rate change,2025-02-01,50,pmf,decrease,0.124
+2025-01-25,1,wk flu hosp rate change,2025-02-01,50,pmf,large_decrease,0.05
+2025-01-25,2,wk flu hosp rate change,2025-02-08,50,pmf,stable,0.502
+2025-01-25,2,wk flu hosp rate change,2025-02-08,50,pmf,increase,0.224
+2025-01-25,2,wk flu hosp rate change,2025-02-08,50,pmf,large_increase,0.05
+2025-01-25,2,wk flu hosp rate change,2025-02-08,50,pmf,decrease,0.191
+2025-01-25,2,wk flu hosp rate change,2025-02-08,50,pmf,large_decrease,0.033
+2025-01-25,3,wk flu hosp rate change,2025-02-15,50,pmf,stable,0.434
+2025-01-25,3,wk flu hosp rate change,2025-02-15,50,pmf,increase,0.266
+2025-01-25,3,wk flu hosp rate change,2025-02-15,50,pmf,large_increase,0.034
+2025-01-25,3,wk flu hosp rate change,2025-02-15,50,pmf,decrease,0.238
+2025-01-25,3,wk flu hosp rate change,2025-02-15,50,pmf,large_decrease,0.028
+2025-01-25,0,wk flu hosp rate change,2025-01-25,51,pmf,stable,0.409
+2025-01-25,0,wk flu hosp rate change,2025-01-25,51,pmf,increase,0.224
+2025-01-25,0,wk flu hosp rate change,2025-01-25,51,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,51,pmf,decrease,0.365
+2025-01-25,0,wk flu hosp rate change,2025-01-25,51,pmf,large_decrease,0.002
+2025-01-25,1,wk flu hosp rate change,2025-02-01,51,pmf,stable,0.489
+2025-01-25,1,wk flu hosp rate change,2025-02-01,51,pmf,increase,0.227
+2025-01-25,1,wk flu hosp rate change,2025-02-01,51,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,51,pmf,decrease,0.284
+2025-01-25,1,wk flu hosp rate change,2025-02-01,51,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,51,pmf,stable,0.53
+2025-01-25,2,wk flu hosp rate change,2025-02-08,51,pmf,increase,0.187
+2025-01-25,2,wk flu hosp rate change,2025-02-08,51,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,51,pmf,decrease,0.283
+2025-01-25,2,wk flu hosp rate change,2025-02-08,51,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,51,pmf,stable,0.63
+2025-01-25,3,wk flu hosp rate change,2025-02-15,51,pmf,increase,0.155
+2025-01-25,3,wk flu hosp rate change,2025-02-15,51,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,51,pmf,decrease,0.215
+2025-01-25,3,wk flu hosp rate change,2025-02-15,51,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,53,pmf,stable,0.602
+2025-01-25,0,wk flu hosp rate change,2025-01-25,53,pmf,increase,0.229
+2025-01-25,0,wk flu hosp rate change,2025-01-25,53,pmf,large_increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,53,pmf,decrease,0.169
+2025-01-25,0,wk flu hosp rate change,2025-01-25,53,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,53,pmf,stable,0.644
+2025-01-25,1,wk flu hosp rate change,2025-02-01,53,pmf,increase,0.2
+2025-01-25,1,wk flu hosp rate change,2025-02-01,53,pmf,large_increase,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,53,pmf,decrease,0.156
+2025-01-25,1,wk flu hosp rate change,2025-02-01,53,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,53,pmf,stable,0.669
+2025-01-25,2,wk flu hosp rate change,2025-02-08,53,pmf,increase,0.177
+2025-01-25,2,wk flu hosp rate change,2025-02-08,53,pmf,large_increase,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,53,pmf,decrease,0.154
+2025-01-25,2,wk flu hosp rate change,2025-02-08,53,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,53,pmf,stable,0.741
+2025-01-25,3,wk flu hosp rate change,2025-02-15,53,pmf,increase,0.143
+2025-01-25,3,wk flu hosp rate change,2025-02-15,53,pmf,large_increase,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,53,pmf,decrease,0.116
+2025-01-25,3,wk flu hosp rate change,2025-02-15,53,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,54,pmf,stable,0.501
+2025-01-25,0,wk flu hosp rate change,2025-01-25,54,pmf,increase,0.254
+2025-01-25,0,wk flu hosp rate change,2025-01-25,54,pmf,large_increase,0.021
+2025-01-25,0,wk flu hosp rate change,2025-01-25,54,pmf,decrease,0.209
+2025-01-25,0,wk flu hosp rate change,2025-01-25,54,pmf,large_decrease,0.015
+2025-01-25,1,wk flu hosp rate change,2025-02-01,54,pmf,stable,0.366
+2025-01-25,1,wk flu hosp rate change,2025-02-01,54,pmf,increase,0.362
+2025-01-25,1,wk flu hosp rate change,2025-02-01,54,pmf,large_increase,0.006
+2025-01-25,1,wk flu hosp rate change,2025-02-01,54,pmf,decrease,0.262
+2025-01-25,1,wk flu hosp rate change,2025-02-01,54,pmf,large_decrease,0.004
+2025-01-25,2,wk flu hosp rate change,2025-02-08,54,pmf,stable,0.363
+2025-01-25,2,wk flu hosp rate change,2025-02-08,54,pmf,increase,0.334
+2025-01-25,2,wk flu hosp rate change,2025-02-08,54,pmf,large_increase,0.003
+2025-01-25,2,wk flu hosp rate change,2025-02-08,54,pmf,decrease,0.298
+2025-01-25,2,wk flu hosp rate change,2025-02-08,54,pmf,large_decrease,0.002
+2025-01-25,3,wk flu hosp rate change,2025-02-15,54,pmf,stable,0.47
+2025-01-25,3,wk flu hosp rate change,2025-02-15,54,pmf,increase,0.279
+2025-01-25,3,wk flu hosp rate change,2025-02-15,54,pmf,large_increase,0.001
+2025-01-25,3,wk flu hosp rate change,2025-02-15,54,pmf,decrease,0.249
+2025-01-25,3,wk flu hosp rate change,2025-02-15,54,pmf,large_decrease,0.001
+2025-01-25,0,wk flu hosp rate change,2025-01-25,55,pmf,stable,0.112
+2025-01-25,0,wk flu hosp rate change,2025-01-25,55,pmf,increase,0.871
+2025-01-25,0,wk flu hosp rate change,2025-01-25,55,pmf,large_increase,0.014
+2025-01-25,0,wk flu hosp rate change,2025-01-25,55,pmf,decrease,0.003
+2025-01-25,0,wk flu hosp rate change,2025-01-25,55,pmf,large_decrease,0
+2025-01-25,1,wk flu hosp rate change,2025-02-01,55,pmf,stable,0.061
+2025-01-25,1,wk flu hosp rate change,2025-02-01,55,pmf,increase,0.927
+2025-01-25,1,wk flu hosp rate change,2025-02-01,55,pmf,large_increase,0.011
+2025-01-25,1,wk flu hosp rate change,2025-02-01,55,pmf,decrease,0.001
+2025-01-25,1,wk flu hosp rate change,2025-02-01,55,pmf,large_decrease,0
+2025-01-25,2,wk flu hosp rate change,2025-02-08,55,pmf,stable,0.089
+2025-01-25,2,wk flu hosp rate change,2025-02-08,55,pmf,increase,0.901
+2025-01-25,2,wk flu hosp rate change,2025-02-08,55,pmf,large_increase,0.008
+2025-01-25,2,wk flu hosp rate change,2025-02-08,55,pmf,decrease,0.002
+2025-01-25,2,wk flu hosp rate change,2025-02-08,55,pmf,large_decrease,0
+2025-01-25,3,wk flu hosp rate change,2025-02-15,55,pmf,stable,0.131
+2025-01-25,3,wk flu hosp rate change,2025-02-15,55,pmf,increase,0.862
+2025-01-25,3,wk flu hosp rate change,2025-02-15,55,pmf,large_increase,0.005
+2025-01-25,3,wk flu hosp rate change,2025-02-15,55,pmf,decrease,0.002
+2025-01-25,3,wk flu hosp rate change,2025-02-15,55,pmf,large_decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,56,pmf,stable,0.41
+2025-01-25,0,wk flu hosp rate change,2025-01-25,56,pmf,increase,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,56,pmf,large_increase,0.166
+2025-01-25,0,wk flu hosp rate change,2025-01-25,56,pmf,decrease,0
+2025-01-25,0,wk flu hosp rate change,2025-01-25,56,pmf,large_decrease,0.424
+2025-01-25,1,wk flu hosp rate change,2025-02-01,56,pmf,stable,0.291
+2025-01-25,1,wk flu hosp rate change,2025-02-01,56,pmf,increase,0.066
+2025-01-25,1,wk flu hosp rate change,2025-02-01,56,pmf,large_increase,0.093
+2025-01-25,1,wk flu hosp rate change,2025-02-01,56,pmf,decrease,0.133
+2025-01-25,1,wk flu hosp rate change,2025-02-01,56,pmf,large_decrease,0.417
+2025-01-25,2,wk flu hosp rate change,2025-02-08,56,pmf,stable,0.233
+2025-01-25,2,wk flu hosp rate change,2025-02-08,56,pmf,increase,0.083
+2025-01-25,2,wk flu hosp rate change,2025-02-08,56,pmf,large_increase,0.059
+2025-01-25,2,wk flu hosp rate change,2025-02-08,56,pmf,decrease,0.192
+2025-01-25,2,wk flu hosp rate change,2025-02-08,56,pmf,large_decrease,0.433
+2025-01-25,3,wk flu hosp rate change,2025-02-15,56,pmf,stable,0.208
+2025-01-25,3,wk flu hosp rate change,2025-02-15,56,pmf,increase,0.099
+2025-01-25,3,wk flu hosp rate change,2025-02-15,56,pmf,large_increase,0.043
+2025-01-25,3,wk flu hosp rate change,2025-02-15,56,pmf,decrease,0.25
+2025-01-25,3,wk flu hosp rate change,2025-02-15,56,pmf,large_decrease,0.4
+2025-01-25,0,wk flu hosp rate change,2025-01-25,US,pmf,stable,0.229
+2025-01-25,0,wk flu hosp rate change,2025-01-25,US,pmf,increase,0.393
+2025-01-25,0,wk flu hosp rate change,2025-01-25,US,pmf,large_increase,0.07
+2025-01-25,0,wk flu hosp rate change,2025-01-25,US,pmf,decrease,0.278
+2025-01-25,0,wk flu hosp rate change,2025-01-25,US,pmf,large_decrease,0.03
+2025-01-25,1,wk flu hosp rate change,2025-02-01,US,pmf,stable,0.243
+2025-01-25,1,wk flu hosp rate change,2025-02-01,US,pmf,increase,0.424
+2025-01-25,1,wk flu hosp rate change,2025-02-01,US,pmf,large_increase,0.048
+2025-01-25,1,wk flu hosp rate change,2025-02-01,US,pmf,decrease,0.27
+2025-01-25,1,wk flu hosp rate change,2025-02-01,US,pmf,large_decrease,0.015
+2025-01-25,2,wk flu hosp rate change,2025-02-08,US,pmf,stable,0.259
+2025-01-25,2,wk flu hosp rate change,2025-02-08,US,pmf,increase,0.409
+2025-01-25,2,wk flu hosp rate change,2025-02-08,US,pmf,large_increase,0.043
+2025-01-25,2,wk flu hosp rate change,2025-02-08,US,pmf,decrease,0.273
+2025-01-25,2,wk flu hosp rate change,2025-02-08,US,pmf,large_decrease,0.016
+2025-01-25,3,wk flu hosp rate change,2025-02-15,US,pmf,stable,0.3
+2025-01-25,3,wk flu hosp rate change,2025-02-15,US,pmf,increase,0.388
+2025-01-25,3,wk flu hosp rate change,2025-02-15,US,pmf,large_increase,0.039
+2025-01-25,3,wk flu hosp rate change,2025-02-15,US,pmf,decrease,0.258
+2025-01-25,3,wk flu hosp rate change,2025-02-15,US,pmf,large_decrease,0.015
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.01,193
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.01,108
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.01,20
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.025,244
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.025,173
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.025,99
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.025,29
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.05,287
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.05,228
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.05,166
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.05,108
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.1,337
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.1,293
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.1,244
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.1,199
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.15,371
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.15,336
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.15,296
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.15,260
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.2,397
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.2,370
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.2,338
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.2,309
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.25,420
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.25,400
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.25,373
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.25,351
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.3,441
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.3,426
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.3,406
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.3,388
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.35,460
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.35,451
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.35,435
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.35,423
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.4,478
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.4,474
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.4,464
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.4,456
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.45,496
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.45,497
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.45,491
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.45,488
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.5,513
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.5,519
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.5,518
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.5,520
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.55,530
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.55,541
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.55,545
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.55,551
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.6,548
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.6,564
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.6,572
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.6,583
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.65,566
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.65,587
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.65,600
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.65,616
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.7,585
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.7,612
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.7,630
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.7,651
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.75,606
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.75,638
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.75,662
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.75,689
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.8,628
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.8,668
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.8,698
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.8,731
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.85,655
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.85,702
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.85,739
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.85,779
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.9,689
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.9,746
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.9,792
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.9,841
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.95,739
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.95,810
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.95,869
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.95,932
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.975,782
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.975,866
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.975,937
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.975,1011
+2025-01-25,0,wk inc flu hosp,2025-01-25,01,quantile,0.99,832
+2025-01-25,1,wk inc flu hosp,2025-02-01,01,quantile,0.99,930
+2025-01-25,2,wk inc flu hosp,2025-02-08,01,quantile,0.99,1015
+2025-01-25,3,wk inc flu hosp,2025-02-15,01,quantile,0.99,1102
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.01,7
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.01,2
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.01,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.025,11
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.025,7
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.025,2
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.025,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.05,15
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.05,11
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.05,7
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.05,5
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.1,19
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.1,16
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.1,12
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.1,10
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.15,21
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.15,19
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.15,16
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.15,14
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.2,23
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.2,21
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.2,19
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.2,17
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.25,25
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.25,23
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.25,21
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.25,20
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.3,27
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.3,25
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.3,23
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.3,22
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.35,28
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.35,27
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.35,25
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.35,25
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.4,30
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.4,29
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.4,27
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.4,27
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.45,31
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.45,31
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.45,29
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.45,29
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.5,33
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.5,32
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.5,31
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.5,31
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.55,34
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.55,34
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.55,33
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.55,33
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.6,35
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.6,36
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.6,35
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.6,35
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.65,37
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.65,37
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.65,37
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.65,37
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.7,38
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.7,39
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.7,39
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.7,39
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.75,40
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.75,41
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.75,41
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.75,41
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.8,42
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.8,43
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.8,43
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.8,44
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.85,44
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.85,46
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.85,46
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.85,47
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.9,46
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.9,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.9,50
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.9,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.95,50
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.95,54
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.95,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.95,57
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.975,54
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.975,58
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.975,60
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.975,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,02,quantile,0.99,58
+2025-01-25,1,wk inc flu hosp,2025-02-01,02,quantile,0.99,63
+2025-01-25,2,wk inc flu hosp,2025-02-08,02,quantile,0.99,65
+2025-01-25,3,wk inc flu hosp,2025-02-15,02,quantile,0.99,68
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.01,444
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.01,353
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.01,262
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.01,177
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.025,459
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.025,379
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.025,298
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.025,221
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.05,472
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.05,402
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.05,329
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.05,259
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.1,487
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.1,429
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.1,364
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.1,302
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.15,498
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.15,446
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.15,388
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.15,331
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.2,506
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.2,461
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.2,407
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.2,355
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.25,513
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.25,473
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.25,423
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.25,375
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.3,519
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.3,483
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.3,438
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.3,393
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.35,525
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.35,494
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.35,452
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.35,409
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.4,530
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.4,503
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.4,465
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.4,425
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.45,535
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.45,512
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.45,477
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.45,440
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.5,541
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.5,522
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.5,489
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.5,455
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.55,546
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.55,531
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.55,502
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.55,470
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.6,551
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.6,540
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.6,514
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.6,486
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.65,557
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.65,549
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.65,527
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.65,501
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.7,562
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.7,560
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.7,541
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.7,518
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.75,569
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.75,570
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.75,555
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.75,536
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.8,576
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.8,583
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.8,572
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.8,556
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.85,584
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.85,597
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.85,591
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.85,579
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.9,594
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.9,614
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.9,615
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.9,608
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.95,609
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.95,641
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.95,650
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.95,652
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.975,622
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.975,664
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.975,681
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.975,690
+2025-01-25,0,wk inc flu hosp,2025-01-25,04,quantile,0.99,637
+2025-01-25,1,wk inc flu hosp,2025-02-01,04,quantile,0.99,690
+2025-01-25,2,wk inc flu hosp,2025-02-08,04,quantile,0.99,717
+2025-01-25,3,wk inc flu hosp,2025-02-15,04,quantile,0.99,733
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.01,173
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.01,161
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.01,142
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.01,130
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.025,180
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.025,171
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.025,155
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.025,146
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.05,186
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.05,180
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.05,167
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.05,160
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.1,193
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.1,190
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.1,180
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.1,176
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.15,197
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.15,197
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.15,189
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.15,186
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.2,201
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.2,203
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.2,196
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.2,195
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.25,204
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.25,207
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.25,202
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.25,202
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.3,207
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.3,212
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.3,208
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.3,209
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.35,209
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.35,215
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.35,213
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.35,215
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.4,212
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.4,219
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.4,217
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.4,221
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.45,214
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.45,223
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.45,222
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.45,226
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.5,216
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.5,226
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.5,227
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.5,232
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.55,219
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.55,230
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.55,231
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.55,237
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.6,221
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.6,233
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.6,236
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.6,243
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.65,224
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.65,237
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.65,241
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.65,249
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.7,226
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.7,241
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.7,246
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.7,255
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.75,229
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.75,245
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.75,251
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.75,262
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.8,232
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.8,250
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.8,257
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.8,269
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.85,236
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.85,255
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.85,265
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.85,278
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.9,240
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.9,262
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.9,274
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.9,288
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.95,247
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.95,272
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.95,287
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.95,304
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.975,253
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.975,281
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.975,298
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.975,318
+2025-01-25,0,wk inc flu hosp,2025-01-25,05,quantile,0.99,260
+2025-01-25,1,wk inc flu hosp,2025-02-01,05,quantile,0.99,291
+2025-01-25,2,wk inc flu hosp,2025-02-08,05,quantile,0.99,312
+2025-01-25,3,wk inc flu hosp,2025-02-15,05,quantile,0.99,334
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.01,1930
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.01,1204
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.01,530
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.025,2201
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.025,1598
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.025,1024
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.025,537
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.05,2435
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.05,1936
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.05,1449
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.05,1039
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.1,2704
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.1,2326
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.1,1939
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.1,1617
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.15,2885
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.15,2589
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.15,2269
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.15,2007
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.2,3030
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.2,2799
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.2,2532
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.2,2317
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.25,3154
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.25,2978
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.25,2757
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.25,2583
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.3,3265
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.3,3139
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.3,2960
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.3,2822
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.35,3368
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.35,3288
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.35,3147
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.35,3044
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.4,3465
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.4,3430
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.4,3325
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.4,3254
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.45,3560
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.45,3567
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.45,3497
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.45,3457
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.5,3653
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.5,3702
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.5,3667
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.5,3657
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.55,3746
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.55,3837
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.55,3836
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.55,3857
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.6,3841
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.6,3974
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.6,4008
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.6,4060
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.65,3938
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.65,4116
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.65,4186
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.65,4270
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.7,4041
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.7,4265
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.7,4374
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.7,4492
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.75,4153
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.75,4426
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.75,4576
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.75,4730
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.8,4276
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.8,4606
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.8,4802
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.8,4997
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.85,4421
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.85,4815
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.85,5064
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.85,5307
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.9,4602
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.9,5078
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.9,5395
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.9,5697
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.95,4871
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.95,5468
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.95,5885
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.95,6275
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.975,5105
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.975,5807
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.975,6310
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.975,6777
+2025-01-25,0,wk inc flu hosp,2025-01-25,06,quantile,0.99,5376
+2025-01-25,1,wk inc flu hosp,2025-02-01,06,quantile,0.99,6200
+2025-01-25,2,wk inc flu hosp,2025-02-08,06,quantile,0.99,6804
+2025-01-25,3,wk inc flu hosp,2025-02-15,06,quantile,0.99,7360
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.01,256
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.01,177
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.01,112
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.01,64
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.025,267
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.025,194
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.025,134
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.025,89
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.05,276
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.05,208
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.05,152
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.05,112
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.1,286
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.1,224
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.1,174
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.1,137
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.15,293
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.15,236
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.15,188
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.15,155
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.2,298
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.2,244
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.2,200
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.2,168
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.25,303
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.25,252
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.25,210
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.25,180
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.3,307
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.3,259
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.3,219
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.3,191
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.35,311
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.35,265
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.35,227
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.35,200
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.4,315
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.4,271
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.4,235
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.4,210
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.45,319
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.45,277
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.45,242
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.45,219
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.5,322
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.5,283
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.5,250
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.5,228
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.55,326
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.55,288
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.55,257
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.55,237
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.6,329
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.6,294
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.6,265
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.6,246
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.65,333
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.65,300
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.65,272
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.65,255
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.7,337
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.7,307
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.7,281
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.7,265
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.75,341
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.75,313
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.75,290
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.75,275
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.8,346
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.8,321
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.8,299
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.8,287
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.85,352
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.85,330
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.85,311
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.85,301
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.9,358
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.9,341
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.9,325
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.9,318
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.95,369
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.95,357
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.95,347
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.95,344
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.975,378
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.975,372
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.975,366
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.975,366
+2025-01-25,0,wk inc flu hosp,2025-01-25,08,quantile,0.99,388
+2025-01-25,1,wk inc flu hosp,2025-02-01,08,quantile,0.99,388
+2025-01-25,2,wk inc flu hosp,2025-02-08,08,quantile,0.99,387
+2025-01-25,3,wk inc flu hosp,2025-02-15,08,quantile,0.99,392
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.01,236
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.01,210
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.01,184
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.01,162
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.025,245
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.025,225
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.025,203
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.025,186
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.05,253
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.05,238
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.05,220
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.05,206
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.1,263
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.1,253
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.1,240
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.1,230
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.15,270
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.15,263
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.15,253
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.15,246
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.2,275
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.2,271
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.2,263
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.2,258
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.25,279
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.25,277
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.25,272
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.25,269
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.3,283
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.3,283
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.3,280
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.3,279
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.35,287
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.35,289
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.35,287
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.35,288
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.4,290
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.4,294
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.4,294
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.4,296
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.45,293
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.45,300
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.45,301
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.45,305
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.5,297
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.5,305
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.5,308
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.5,313
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.55,300
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.55,310
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.55,315
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.55,321
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.6,303
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.6,315
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.6,322
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.6,329
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.65,307
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.65,320
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.65,329
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.65,338
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.7,311
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.7,326
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.7,336
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.7,347
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.75,315
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.75,332
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.75,344
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.75,357
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.8,319
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.8,339
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.8,353
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.8,368
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.85,324
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.85,347
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.85,363
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.85,380
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.9,331
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.9,357
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.9,376
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.9,396
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.95,340
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.95,371
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.95,396
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.95,420
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.975,348
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.975,384
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.975,413
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.975,440
+2025-01-25,0,wk inc flu hosp,2025-01-25,09,quantile,0.99,358
+2025-01-25,1,wk inc flu hosp,2025-02-01,09,quantile,0.99,399
+2025-01-25,2,wk inc flu hosp,2025-02-08,09,quantile,0.99,432
+2025-01-25,3,wk inc flu hosp,2025-02-15,09,quantile,0.99,464
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.01,38
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.01,30
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.01,22
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.01,18
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.025,42
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.025,35
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.025,27
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.025,23
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.05,46
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.05,39
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.05,32
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.05,29
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.1,50
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.1,44
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.1,37
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.1,34
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.15,52
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.15,47
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.15,41
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.15,38
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.2,55
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.2,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.2,44
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.2,42
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.25,56
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.25,52
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.25,46
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.25,44
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.3,58
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.3,54
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.3,49
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.3,47
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.35,60
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.35,55
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.35,51
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.35,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.4,61
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.4,57
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.4,53
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.4,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.45,62
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.45,59
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.45,54
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.45,53
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.5,64
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.5,61
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.5,56
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.5,55
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.55,65
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.55,62
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.55,58
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.55,57
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.6,67
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.6,64
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.6,60
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.6,59
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.65,68
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.65,66
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.65,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.65,61
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.7,70
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.7,68
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.7,64
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.7,64
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.75,71
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.75,70
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.75,66
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.75,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.8,73
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.8,72
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.8,69
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.8,69
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.85,75
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.85,74
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.85,72
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.85,72
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.9,78
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.9,78
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.9,75
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.9,76
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.95,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.95,82
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.95,81
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.95,82
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.975,85
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.975,87
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.975,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.975,87
+2025-01-25,0,wk inc flu hosp,2025-01-25,10,quantile,0.99,89
+2025-01-25,1,wk inc flu hosp,2025-02-01,10,quantile,0.99,91
+2025-01-25,2,wk inc flu hosp,2025-02-08,10,quantile,0.99,91
+2025-01-25,3,wk inc flu hosp,2025-02-15,10,quantile,0.99,93
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.01,1763
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.01,1442
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.01,1095
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.01,753
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.025,1907
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.025,1647
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.025,1359
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.025,1076
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.05,2031
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.05,1823
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.05,1587
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.05,1354
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.1,2173
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.1,2027
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.1,1849
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.1,1675
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.15,2270
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.15,2164
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.15,2026
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.15,1891
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.2,2346
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.2,2273
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.2,2166
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.2,2063
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.25,2412
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.25,2366
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.25,2287
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.25,2210
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.3,2471
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.3,2450
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.3,2396
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.3,2342
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.35,2526
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.35,2528
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.35,2496
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.35,2465
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.4,2578
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.4,2602
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.4,2591
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.4,2581
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.45,2628
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.45,2674
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.45,2683
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.45,2694
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.5,2677
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.5,2744
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.5,2774
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.5,2805
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.55,2726
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.55,2814
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.55,2865
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.55,2916
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.6,2777
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.6,2886
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.6,2957
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.6,3028
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.65,2828
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.65,2960
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.65,3052
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.65,3145
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.7,2883
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.7,3037
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.7,3153
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.7,3267
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.75,2942
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.75,3121
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.75,3261
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.75,3400
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.8,3008
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.8,3215
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.8,3382
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.8,3547
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.85,3084
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.85,3324
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.85,3522
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.85,3719
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.9,3181
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.9,3461
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.9,3699
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.9,3935
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.95,3323
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.95,3664
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.95,3962
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.95,4256
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.975,3447
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.975,3841
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.975,4189
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.975,4534
+2025-01-25,0,wk inc flu hosp,2025-01-25,12,quantile,0.99,3591
+2025-01-25,1,wk inc flu hosp,2025-02-01,12,quantile,0.99,4046
+2025-01-25,2,wk inc flu hosp,2025-02-08,12,quantile,0.99,4454
+2025-01-25,3,wk inc flu hosp,2025-02-15,12,quantile,0.99,4857
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.01,871
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.01,835
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.01,791
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.01,757
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.025,887
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.025,860
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.025,824
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.025,798
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.05,901
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.05,882
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.05,853
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.05,832
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.1,917
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.1,908
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.1,886
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.1,873
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.15,928
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.15,925
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.15,909
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.15,900
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.2,936
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.2,939
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.2,926
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.2,921
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.25,944
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.25,950
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.25,942
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.25,940
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.3,951
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.3,961
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.3,956
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.3,957
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.35,957
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.35,970
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.35,968
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.35,972
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.4,963
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.4,980
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.4,980
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.4,987
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.45,968
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.45,989
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.45,992
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.45,1001
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.5,974
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.5,997
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.5,1003
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.5,1015
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.55,979
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.55,1006
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.55,1015
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.55,1028
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.6,985
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.6,1015
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.6,1027
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.6,1043
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.65,991
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.65,1024
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.65,1039
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.65,1057
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.7,997
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.7,1034
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.7,1051
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.7,1073
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.75,1004
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.75,1045
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.75,1065
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.75,1089
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.8,1011
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.8,1056
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.8,1081
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.8,1108
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.85,1020
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.85,1070
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.85,1098
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.85,1129
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.9,1030
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.9,1087
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.9,1121
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.9,1156
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.95,1047
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.95,1112
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.95,1154
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.95,1197
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.975,1060
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.975,1134
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.975,1183
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.975,1232
+2025-01-25,0,wk inc flu hosp,2025-01-25,13,quantile,0.99,1077
+2025-01-25,1,wk inc flu hosp,2025-02-01,13,quantile,0.99,1160
+2025-01-25,2,wk inc flu hosp,2025-02-08,13,quantile,0.99,1216
+2025-01-25,3,wk inc flu hosp,2025-02-15,13,quantile,0.99,1272
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.01,62
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.01,54
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.01,45
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.01,39
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.025,66
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.025,58
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.025,50
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.025,45
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.05,69
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.05,62
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.05,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.05,50
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.1,73
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.1,67
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.1,60
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.1,55
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.15,76
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.15,70
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.15,63
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.15,59
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.2,78
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.2,72
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.2,66
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.2,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.25,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.25,74
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.25,68
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.25,64
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.3,81
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.3,76
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.3,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.3,67
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.35,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.35,78
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.35,72
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.35,69
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.4,84
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.4,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.4,74
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.4,71
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.45,85
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.45,81
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.45,76
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.45,73
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.5,86
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.5,82
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.5,78
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.5,75
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.55,87
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.55,84
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.55,79
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.55,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.6,89
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.6,85
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.6,81
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.6,79
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.65,90
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.65,87
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.65,83
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.65,81
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.7,91
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.7,89
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.7,85
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.7,83
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.75,93
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.75,91
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.75,87
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.75,85
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.8,95
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.8,93
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.8,89
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.8,88
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.85,97
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.85,95
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.85,92
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.85,91
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.9,99
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.9,98
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.9,96
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.9,94
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.95,103
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.95,103
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.95,101
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.95,100
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.975,106
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.975,107
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.975,105
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.975,105
+2025-01-25,0,wk inc flu hosp,2025-01-25,15,quantile,0.99,110
+2025-01-25,1,wk inc flu hosp,2025-02-01,15,quantile,0.99,111
+2025-01-25,2,wk inc flu hosp,2025-02-08,15,quantile,0.99,110
+2025-01-25,3,wk inc flu hosp,2025-02-15,15,quantile,0.99,110
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.01,90
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.01,76
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.01,61
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.01,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.025,95
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.025,84
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.025,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.025,60
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.05,100
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.05,90
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.05,78
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.05,70
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.1,105
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.1,98
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.1,88
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.1,81
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.15,108
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.15,103
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.15,94
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.15,88
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.2,111
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.2,107
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.2,99
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.2,94
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.25,114
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.25,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.25,103
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.25,99
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.3,116
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.3,113
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.3,107
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.3,104
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.35,118
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.35,116
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.35,111
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.35,108
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.4,120
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.4,119
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.4,114
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.4,112
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.45,121
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.45,121
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.45,118
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.45,116
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.5,123
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.5,124
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.5,121
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.5,120
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.55,125
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.55,126
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.55,124
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.55,124
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.6,127
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.6,129
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.6,128
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.6,127
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.65,129
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.65,132
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.65,131
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.65,132
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.7,131
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.7,135
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.7,135
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.7,136
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.75,133
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.75,138
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.75,138
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.75,140
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.8,135
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.8,141
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.8,143
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.8,145
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.85,138
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.85,145
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.85,148
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.85,151
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.9,142
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.9,150
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.9,154
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.9,159
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.95,147
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.95,158
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.95,164
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.95,170
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.975,151
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.975,164
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.975,172
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.975,179
+2025-01-25,0,wk inc flu hosp,2025-01-25,16,quantile,0.99,156
+2025-01-25,1,wk inc flu hosp,2025-02-01,16,quantile,0.99,172
+2025-01-25,2,wk inc flu hosp,2025-02-08,16,quantile,0.99,181
+2025-01-25,3,wk inc flu hosp,2025-02-15,16,quantile,0.99,191
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.01,1075
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.01,953
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.01,848
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.01,770
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.025,1098
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.025,986
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.025,888
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.025,815
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.05,1117
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.05,1013
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.05,922
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.05,854
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.1,1139
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.1,1046
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.1,961
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.1,899
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.15,1154
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.15,1067
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.15,987
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.15,929
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.2,1166
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.2,1085
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.2,1008
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.2,953
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.25,1176
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.25,1099
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.25,1026
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.25,973
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.3,1185
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.3,1113
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.3,1042
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.3,991
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.35,1194
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.35,1125
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.35,1057
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.35,1008
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.4,1202
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.4,1137
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.4,1072
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.4,1025
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.45,1209
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.45,1148
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.45,1085
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.45,1040
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.5,1217
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.5,1159
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.5,1099
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.5,1056
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.55,1225
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.55,1170
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.55,1113
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.55,1071
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.6,1232
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.6,1182
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.6,1126
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.6,1087
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.65,1240
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.65,1193
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.65,1141
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.65,1103
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.7,1249
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.7,1206
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.7,1156
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.7,1120
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.75,1258
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.75,1219
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.75,1172
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.75,1138
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.8,1268
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.8,1234
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.8,1190
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.8,1159
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.85,1280
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.85,1251
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.85,1211
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.85,1183
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.9,1295
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.9,1273
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.9,1237
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.9,1213
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.95,1317
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.95,1305
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.95,1276
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.95,1257
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.975,1336
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.975,1333
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.975,1310
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.975,1296
+2025-01-25,0,wk inc flu hosp,2025-01-25,17,quantile,0.99,1359
+2025-01-25,1,wk inc flu hosp,2025-02-01,17,quantile,0.99,1365
+2025-01-25,2,wk inc flu hosp,2025-02-08,17,quantile,0.99,1350
+2025-01-25,3,wk inc flu hosp,2025-02-15,17,quantile,0.99,1341
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.01,453
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.01,406
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.01,357
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.01,316
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.025,465
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.025,426
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.025,383
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.025,349
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.05,476
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.05,443
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.05,406
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.05,378
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.1,488
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.1,463
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.1,433
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.1,410
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.15,496
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.15,476
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.15,451
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.15,433
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.2,502
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.2,486
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.2,465
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.2,450
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.25,508
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.25,496
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.25,477
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.25,465
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.3,513
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.3,504
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.3,488
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.3,479
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.35,517
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.35,511
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.35,499
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.35,491
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.4,522
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.4,518
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.4,508
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.4,503
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.45,526
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.45,525
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.45,518
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.45,515
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.5,530
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.5,532
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.5,527
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.5,526
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.55,534
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.55,539
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.55,536
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.55,537
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.6,538
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.6,546
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.6,545
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.6,549
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.65,543
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.65,553
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.65,555
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.65,561
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.7,547
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.7,561
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.7,565
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.7,573
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.75,552
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.75,569
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.75,576
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.75,587
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.8,558
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.8,578
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.8,588
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.8,602
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.85,564
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.85,589
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.85,603
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.85,620
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.9,572
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.9,602
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.9,620
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.9,642
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.95,584
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.95,622
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.95,647
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.95,674
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.975,595
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.975,639
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.975,670
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.975,703
+2025-01-25,0,wk inc flu hosp,2025-01-25,18,quantile,0.99,607
+2025-01-25,1,wk inc flu hosp,2025-02-01,18,quantile,0.99,659
+2025-01-25,2,wk inc flu hosp,2025-02-08,18,quantile,0.99,697
+2025-01-25,3,wk inc flu hosp,2025-02-15,18,quantile,0.99,736
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.01,195
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.01,169
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.01,144
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.01,126
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.025,200
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.025,178
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.025,155
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.025,140
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.05,205
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.05,185
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.05,165
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.05,151
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.1,210
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.1,194
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.1,176
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.1,164
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.15,214
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.15,200
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.15,184
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.15,173
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.2,217
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.2,204
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.2,190
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.2,180
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.25,219
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.25,208
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.25,195
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.25,187
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.3,221
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.3,212
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.3,199
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.3,192
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.35,224
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.35,215
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.35,204
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.35,197
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.4,225
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.4,218
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.4,208
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.4,202
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.45,227
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.45,221
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.45,212
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.45,207
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.5,229
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.5,224
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.5,216
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.5,211
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.55,231
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.55,227
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.55,219
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.55,216
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.6,233
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.6,230
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.6,223
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.6,221
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.65,235
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.65,233
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.65,227
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.65,225
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.7,237
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.7,236
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.7,232
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.7,230
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.75,239
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.75,240
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.75,236
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.75,236
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.8,242
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.8,244
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.8,241
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.8,242
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.85,245
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.85,248
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.85,247
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.85,249
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.9,248
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.9,254
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.9,255
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.9,258
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.95,254
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.95,263
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.95,266
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.95,271
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.975,258
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.975,270
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.975,276
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.975,283
+2025-01-25,0,wk inc flu hosp,2025-01-25,19,quantile,0.99,264
+2025-01-25,1,wk inc flu hosp,2025-02-01,19,quantile,0.99,279
+2025-01-25,2,wk inc flu hosp,2025-02-08,19,quantile,0.99,287
+2025-01-25,3,wk inc flu hosp,2025-02-15,19,quantile,0.99,296
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.01,163
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.01,149
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.01,136
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.01,126
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.025,168
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.025,156
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.025,145
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.025,137
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.05,172
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.05,163
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.05,153
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.05,146
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.1,177
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.1,170
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.1,163
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.1,157
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.15,181
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.15,175
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.15,169
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.15,165
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.2,184
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.2,179
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.2,174
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.2,170
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.25,186
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.25,183
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.25,178
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.25,175
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.3,188
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.3,186
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.3,182
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.3,180
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.35,190
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.35,189
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.35,186
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.35,184
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.4,192
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.4,192
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.4,189
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.4,188
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.45,194
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.45,194
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.45,192
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.45,192
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.5,195
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.5,197
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.5,196
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.5,195
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.55,197
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.55,199
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.55,199
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.55,199
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.6,199
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.6,202
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.6,202
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.6,203
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.65,201
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.65,205
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.65,205
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.65,207
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.7,203
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.7,208
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.7,209
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.7,211
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.75,205
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.75,211
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.75,213
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.75,215
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.8,207
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.8,214
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.8,217
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.8,220
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.85,210
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.85,218
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.85,222
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.85,226
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.9,214
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.9,223
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.9,228
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.9,233
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.95,219
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.95,231
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.95,238
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.95,244
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.975,223
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.975,237
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.975,246
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.975,253
+2025-01-25,0,wk inc flu hosp,2025-01-25,20,quantile,0.99,228
+2025-01-25,1,wk inc flu hosp,2025-02-01,20,quantile,0.99,245
+2025-01-25,2,wk inc flu hosp,2025-02-08,20,quantile,0.99,255
+2025-01-25,3,wk inc flu hosp,2025-02-15,20,quantile,0.99,264
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.01,291
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.01,254
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.01,219
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.01,189
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.025,301
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.025,271
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.025,241
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.025,215
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.05,310
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.05,286
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.05,260
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.05,238
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.1,321
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.1,303
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.1,282
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.1,264
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.15,328
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.15,314
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.15,297
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.15,281
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.2,333
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.2,323
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.2,308
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.2,295
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.25,338
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.25,331
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.25,318
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.25,307
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.3,342
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.3,338
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.3,327
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.3,318
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.35,346
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.35,344
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.35,336
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.35,328
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.4,350
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.4,351
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.4,344
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.4,338
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.45,354
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.45,356
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.45,351
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.45,347
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.5,357
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.5,362
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.5,359
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.5,356
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.55,361
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.55,368
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.55,367
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.55,365
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.6,364
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.6,374
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.6,374
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.6,374
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.65,368
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.65,380
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.65,382
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.65,384
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.7,372
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.7,387
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.7,391
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.7,394
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.75,377
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.75,394
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.75,400
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.75,404
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.8,381
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.8,401
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.8,410
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.8,416
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.85,387
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.85,411
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.85,421
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.85,430
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.9,394
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.9,422
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.9,436
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.9,448
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.95,404
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.95,439
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.95,458
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.95,474
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.975,413
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.975,453
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.975,477
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.975,497
+2025-01-25,0,wk inc flu hosp,2025-01-25,21,quantile,0.99,424
+2025-01-25,1,wk inc flu hosp,2025-02-01,21,quantile,0.99,470
+2025-01-25,2,wk inc flu hosp,2025-02-08,21,quantile,0.99,499
+2025-01-25,3,wk inc flu hosp,2025-02-15,21,quantile,0.99,523
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.01,390
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.01,360
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.01,329
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.01,312
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.025,403
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.025,378
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.025,351
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.025,337
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.05,415
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.05,394
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.05,370
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.05,358
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.1,427
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.1,412
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.1,391
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.1,383
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.15,436
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.15,424
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.15,406
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.15,400
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.2,443
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.2,434
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.2,418
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.2,413
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.25,449
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.25,442
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.25,428
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.25,424
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.3,454
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.3,449
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.3,437
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.3,435
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.35,459
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.35,456
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.35,445
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.35,444
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.4,464
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.4,463
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.4,453
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.4,453
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.45,468
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.45,469
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.45,460
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.45,462
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.5,473
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.5,475
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.5,468
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.5,470
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.55,477
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.55,482
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.55,475
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.55,479
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.6,482
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.6,488
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.6,483
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.6,488
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.65,487
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.65,495
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.65,491
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.65,497
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.7,491
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.7,502
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.7,499
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.7,506
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.75,497
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.75,509
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.75,508
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.75,516
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.8,503
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.8,517
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.8,518
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.8,528
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.85,510
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.85,527
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.85,530
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.85,541
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.9,518
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.9,539
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.9,545
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.9,558
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.95,531
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.95,557
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.95,566
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.95,583
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.975,542
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.975,573
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.975,585
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.975,604
+2025-01-25,0,wk inc flu hosp,2025-01-25,22,quantile,0.99,555
+2025-01-25,1,wk inc flu hosp,2025-02-01,22,quantile,0.99,591
+2025-01-25,2,wk inc flu hosp,2025-02-08,22,quantile,0.99,607
+2025-01-25,3,wk inc flu hosp,2025-02-15,22,quantile,0.99,629
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.01,57
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.01,46
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.01,36
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.01,29
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.025,61
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.025,52
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.025,43
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.025,36
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.05,65
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.05,56
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.05,48
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.05,42
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.1,69
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.1,62
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.1,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.1,50
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.15,72
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.15,65
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.15,59
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.15,54
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.2,74
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.2,68
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.2,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.2,58
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.25,75
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.25,71
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.25,65
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.25,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.3,77
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.3,73
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.3,68
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.3,65
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.35,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.35,75
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.35,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.35,67
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.4,80
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.4,77
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.4,73
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.4,70
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.45,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.45,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.45,75
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.45,72
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.5,83
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.5,81
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.5,77
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.5,75
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.55,84
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.55,83
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.55,79
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.55,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.6,86
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.6,85
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.6,82
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.6,80
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.65,87
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.65,87
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.65,84
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.65,83
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.7,89
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.7,89
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.7,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.7,85
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.75,90
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.75,91
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.75,89
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.75,88
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.8,92
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.8,93
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.8,92
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.8,92
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.85,94
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.85,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.85,95
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.85,95
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.9,97
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.9,100
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.9,100
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.9,100
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.95,101
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.95,105
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.95,106
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.95,107
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.975,104
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.975,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.975,112
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.975,114
+2025-01-25,0,wk inc flu hosp,2025-01-25,23,quantile,0.99,108
+2025-01-25,1,wk inc flu hosp,2025-02-01,23,quantile,0.99,115
+2025-01-25,2,wk inc flu hosp,2025-02-08,23,quantile,0.99,118
+2025-01-25,3,wk inc flu hosp,2025-02-15,23,quantile,0.99,121
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.01,414
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.01,373
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.01,325
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.01,283
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.025,424
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.025,390
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.025,347
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.025,311
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.05,433
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.05,404
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.05,366
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.05,334
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.1,443
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.1,421
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.1,389
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.1,361
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.15,450
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.15,432
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.15,404
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.15,379
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.2,456
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.2,441
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.2,416
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.2,394
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.25,461
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.25,449
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.25,426
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.25,406
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.3,465
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.3,456
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.3,435
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.3,417
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.35,469
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.35,462
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.35,444
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.35,428
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.4,472
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.4,469
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.4,452
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.4,437
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.45,476
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.45,474
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.45,460
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.45,447
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.5,480
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.5,480
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.5,467
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.5,456
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.55,483
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.55,486
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.55,475
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.55,465
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.6,487
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.6,492
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.6,483
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.6,475
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.65,490
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.65,498
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.65,491
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.65,485
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.7,494
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.7,505
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.7,500
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.7,495
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.75,499
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.75,511
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.75,509
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.75,506
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.8,503
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.8,519
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.8,519
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.8,519
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.85,509
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.85,528
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.85,531
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.85,533
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.9,516
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.9,540
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.9,546
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.9,551
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.95,526
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.95,556
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.95,568
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.95,578
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.975,535
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.975,571
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.975,588
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.975,602
+2025-01-25,0,wk inc flu hosp,2025-01-25,24,quantile,0.99,545
+2025-01-25,1,wk inc flu hosp,2025-02-01,24,quantile,0.99,588
+2025-01-25,2,wk inc flu hosp,2025-02-08,24,quantile,0.99,610
+2025-01-25,3,wk inc flu hosp,2025-02-15,24,quantile,0.99,629
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.01,693
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.01,692
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.01,674
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.01,655
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.025,704
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.025,710
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.025,699
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.025,687
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.05,713
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.05,725
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.05,721
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.05,714
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.1,724
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.1,743
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.1,746
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.1,745
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.15,731
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.15,755
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.15,763
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.15,766
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.2,736
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.2,765
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.2,776
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.2,783
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.25,741
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.25,773
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.25,788
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.25,798
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.3,746
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.3,781
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.3,798
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.3,811
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.35,750
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.35,788
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.35,807
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.35,823
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.4,754
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.4,794
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.4,817
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.4,834
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.45,757
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.45,800
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.45,825
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.45,845
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.5,761
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.5,807
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.5,834
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.5,856
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.55,765
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.55,813
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.55,842
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.55,867
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.6,768
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.6,819
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.6,851
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.6,878
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.65,772
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.65,826
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.65,860
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.65,889
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.7,776
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.7,833
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.7,870
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.7,901
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.75,781
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.75,840
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.75,880
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.75,914
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.8,785
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.8,848
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.8,892
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.8,929
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.85,791
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.85,858
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.85,905
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.85,946
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.9,798
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.9,870
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.9,922
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.9,967
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.95,809
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.95,888
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.95,947
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.95,998
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.975,818
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.975,904
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.975,968
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.975,1025
+2025-01-25,0,wk inc flu hosp,2025-01-25,25,quantile,0.99,829
+2025-01-25,1,wk inc flu hosp,2025-02-01,25,quantile,0.99,922
+2025-01-25,2,wk inc flu hosp,2025-02-08,25,quantile,0.99,993
+2025-01-25,3,wk inc flu hosp,2025-02-15,25,quantile,0.99,1057
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.01,386
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.01,317
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.01,246
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.01,187
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.025,407
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.025,351
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.025,292
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.025,243
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.05,425
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.05,380
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.05,331
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.05,290
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.1,445
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.1,413
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.1,376
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.1,346
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.15,459
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.15,436
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.15,406
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.15,383
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.2,471
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.2,454
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.2,430
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.2,412
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.25,480
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.25,470
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.25,451
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.25,438
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.3,489
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.3,484
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.3,469
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.3,460
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.35,497
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.35,497
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.35,486
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.35,481
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.4,504
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.4,509
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.4,503
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.4,501
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.45,511
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.45,521
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.45,519
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.45,521
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.5,519
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.5,532
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.5,534
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.5,540
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.55,526
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.55,544
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.55,550
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.55,559
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.6,533
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.6,556
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.6,565
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.6,578
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.65,541
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.65,568
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.65,582
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.65,598
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.7,549
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.7,581
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.7,599
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.7,619
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.75,557
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.75,595
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.75,617
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.75,642
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.8,567
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.8,610
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.8,638
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.8,667
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.85,578
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.85,628
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.85,662
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.85,697
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.9,592
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.9,651
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.9,693
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.9,734
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.95,612
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.95,685
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.95,737
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.95,789
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.975,630
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.975,714
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.975,776
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.975,837
+2025-01-25,0,wk inc flu hosp,2025-01-25,26,quantile,0.99,651
+2025-01-25,1,wk inc flu hosp,2025-02-01,26,quantile,0.99,748
+2025-01-25,2,wk inc flu hosp,2025-02-08,26,quantile,0.99,822
+2025-01-25,3,wk inc flu hosp,2025-02-15,26,quantile,0.99,892
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.01,832
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.01,736
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.01,629
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.01,533
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.025,843
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.025,754
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.025,656
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.025,567
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.05,852
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.05,771
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.05,679
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.05,596
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.1,862
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.1,789
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.1,705
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.1,629
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.15,869
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.15,802
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.15,723
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.15,651
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.2,874
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.2,812
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.2,737
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.2,669
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.25,879
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.25,820
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.25,749
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.25,684
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.3,883
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.3,828
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.3,760
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.3,698
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.35,887
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.35,835
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.35,770
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.35,711
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.4,891
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.4,842
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.4,780
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.4,723
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.45,895
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.45,848
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.45,789
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.45,734
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.5,898
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.5,855
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.5,798
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.5,746
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.55,902
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.55,861
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.55,807
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.55,757
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.6,905
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.6,868
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.6,816
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.6,769
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.65,909
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.65,875
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.65,826
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.65,781
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.7,913
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.7,882
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.7,836
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.7,794
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.75,917
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.75,890
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.75,847
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.75,807
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.8,922
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.8,898
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.8,859
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.8,823
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.85,928
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.85,908
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.85,873
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.85,840
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.9,934
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.9,921
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.9,891
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.9,863
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.95,945
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.95,939
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.95,917
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.95,896
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.975,954
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.975,956
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.975,940
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.975,925
+2025-01-25,0,wk inc flu hosp,2025-01-25,27,quantile,0.99,964
+2025-01-25,1,wk inc flu hosp,2025-02-01,27,quantile,0.99,974
+2025-01-25,2,wk inc flu hosp,2025-02-08,27,quantile,0.99,966
+2025-01-25,3,wk inc flu hosp,2025-02-15,27,quantile,0.99,958
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.01,158
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.01,132
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.01,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.01,93
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.025,167
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.025,144
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.025,122
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.025,108
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.05,174
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.05,153
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.05,134
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.05,121
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.1,182
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.1,165
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.1,147
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.1,136
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.15,188
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.15,172
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.15,156
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.15,146
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.2,192
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.2,178
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.2,163
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.2,154
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.25,196
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.25,183
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.25,169
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.25,161
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.3,199
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.3,188
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.3,175
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.3,167
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.35,203
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.35,192
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.35,180
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.35,173
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.4,206
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.4,197
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.4,185
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.4,178
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.45,208
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.45,200
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.45,189
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.45,183
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.5,211
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.5,204
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.5,194
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.5,189
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.55,214
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.55,208
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.55,199
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.55,194
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.6,217
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.6,212
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.6,203
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.6,199
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.65,220
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.65,216
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.65,208
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.65,204
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.7,223
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.7,221
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.7,213
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.7,210
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.75,227
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.75,225
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.75,219
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.75,216
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.8,230
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.8,230
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.8,225
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.8,223
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.85,235
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.85,236
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.85,232
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.85,231
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.9,240
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.9,244
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.9,241
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.9,241
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.95,249
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.95,255
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.95,254
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.95,256
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.975,256
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.975,265
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.975,266
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.975,269
+2025-01-25,0,wk inc flu hosp,2025-01-25,28,quantile,0.99,264
+2025-01-25,1,wk inc flu hosp,2025-02-01,28,quantile,0.99,276
+2025-01-25,2,wk inc flu hosp,2025-02-08,28,quantile,0.99,279
+2025-01-25,3,wk inc flu hosp,2025-02-15,28,quantile,0.99,284
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.01,337
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.01,258
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.01,190
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.01,133
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.025,350
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.025,280
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.025,218
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.025,169
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.05,361
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.05,298
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.05,243
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.05,200
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.1,374
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.1,319
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.1,272
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.1,235
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.15,383
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.15,334
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.15,291
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.15,259
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.2,390
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.2,345
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.2,306
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.2,278
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.25,395
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.25,355
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.25,320
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.25,294
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.3,401
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.3,363
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.3,331
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.3,309
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.35,406
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.35,372
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.35,342
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.35,322
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.4,410
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.4,379
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.4,353
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.4,335
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.45,415
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.45,387
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.45,363
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.45,347
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.5,419
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.5,394
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.5,373
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.5,360
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.55,424
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.55,401
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.55,383
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.55,372
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.6,428
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.6,409
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.6,393
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.6,384
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.65,433
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.65,417
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.65,403
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.65,397
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.7,438
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.7,425
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.7,414
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.7,411
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.75,443
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.75,433
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.75,426
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.75,425
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.8,449
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.8,443
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.8,439
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.8,441
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.85,456
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.85,455
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.85,454
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.85,460
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.9,465
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.9,469
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.9,474
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.9,484
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.95,477
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.95,490
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.95,502
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.95,520
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.975,489
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.975,509
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.975,527
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.975,550
+2025-01-25,0,wk inc flu hosp,2025-01-25,29,quantile,0.99,502
+2025-01-25,1,wk inc flu hosp,2025-02-01,29,quantile,0.99,530
+2025-01-25,2,wk inc flu hosp,2025-02-08,29,quantile,0.99,556
+2025-01-25,3,wk inc flu hosp,2025-02-15,29,quantile,0.99,586
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.01,34
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.01,14
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.01,1
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.025,40
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.025,23
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.025,11
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.025,3
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.05,45
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.05,30
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.05,20
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.05,12
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.1,52
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.1,39
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.1,30
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.1,23
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.15,56
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.15,45
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.15,36
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.15,31
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.2,60
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.2,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.2,42
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.2,37
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.25,62
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.25,53
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.25,46
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.25,42
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.3,65
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.3,57
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.3,51
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.3,46
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.35,68
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.35,60
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.35,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.35,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.4,70
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.4,64
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.4,58
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.4,55
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.45,72
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.45,67
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.45,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.45,59
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.5,74
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.5,70
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.5,65
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.5,63
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.55,76
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.55,73
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.55,69
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.55,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.6,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.6,76
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.6,72
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.6,70
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.65,81
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.65,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.65,76
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.65,74
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.7,83
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.7,82
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.7,80
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.7,79
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.75,86
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.75,86
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.75,84
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.75,83
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.8,89
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.8,90
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.8,89
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.8,88
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.85,92
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.85,94
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.85,94
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.85,94
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.9,97
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.9,100
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.9,101
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.9,102
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.95,103
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.95,109
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.95,111
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.95,113
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.975,109
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.975,116
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.975,120
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.975,122
+2025-01-25,0,wk inc flu hosp,2025-01-25,30,quantile,0.99,115
+2025-01-25,1,wk inc flu hosp,2025-02-01,30,quantile,0.99,125
+2025-01-25,2,wk inc flu hosp,2025-02-08,30,quantile,0.99,130
+2025-01-25,3,wk inc flu hosp,2025-02-15,30,quantile,0.99,134
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.01,99
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.01,90
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.01,81
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.01,74
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.025,103
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.025,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.025,88
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.025,82
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.05,107
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.05,101
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.05,94
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.05,89
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.1,111
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.1,106
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.1,101
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.1,97
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.15,114
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.15,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.15,105
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.15,102
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.2,116
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.2,113
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.2,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.2,107
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.25,118
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.25,116
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.25,112
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.25,110
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.3,119
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.3,118
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.3,115
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.3,114
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.35,121
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.35,120
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.35,118
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.35,117
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.4,122
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.4,122
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.4,120
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.4,119
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.45,124
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.45,124
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.45,123
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.45,122
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.5,125
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.5,126
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.5,125
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.5,125
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.55,126
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.55,128
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.55,128
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.55,128
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.6,128
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.6,130
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.6,130
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.6,131
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.65,129
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.65,132
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.65,132
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.65,134
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.7,131
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.7,135
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.7,135
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.7,137
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.75,132
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.75,137
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.75,138
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.75,140
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.8,134
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.8,140
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.8,141
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.8,144
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.85,136
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.85,143
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.85,145
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.85,148
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.9,139
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.9,146
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.9,150
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.9,153
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.95,143
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.95,152
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.95,156
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.95,161
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.975,147
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.975,157
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.975,162
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.975,168
+2025-01-25,0,wk inc flu hosp,2025-01-25,31,quantile,0.99,151
+2025-01-25,1,wk inc flu hosp,2025-02-01,31,quantile,0.99,163
+2025-01-25,2,wk inc flu hosp,2025-02-08,31,quantile,0.99,169
+2025-01-25,3,wk inc flu hosp,2025-02-15,31,quantile,0.99,176
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.01,121
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.01,85
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.01,56
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.01,38
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.025,127
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.025,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.025,69
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.025,53
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.05,133
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.05,105
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.05,80
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.05,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.1,140
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.1,115
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.1,93
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.1,81
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.15,145
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.15,122
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.15,102
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.15,91
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.2,149
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.2,128
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.2,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.2,99
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.25,152
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.25,132
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.25,115
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.25,106
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.3,154
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.3,137
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.3,120
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.3,112
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.35,157
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.35,141
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.35,125
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.35,118
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.4,160
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.4,144
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.4,130
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.4,123
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.45,162
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.45,148
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.45,135
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.45,128
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.5,164
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.5,151
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.5,139
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.5,133
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.55,167
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.55,155
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.55,144
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.55,139
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.6,169
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.6,159
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.6,148
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.6,144
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.65,172
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.65,162
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.65,153
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.65,149
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.7,174
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.7,166
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.7,158
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.7,155
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.75,177
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.75,171
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.75,163
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.75,161
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.8,180
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.8,175
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.8,169
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.8,168
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.85,184
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.85,181
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.85,176
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.85,176
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.9,188
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.9,188
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.9,185
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.9,186
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.95,195
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.95,198
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.95,198
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.95,201
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.975,201
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.975,207
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.975,209
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.975,214
+2025-01-25,0,wk inc flu hosp,2025-01-25,32,quantile,0.99,208
+2025-01-25,1,wk inc flu hosp,2025-02-01,32,quantile,0.99,218
+2025-01-25,2,wk inc flu hosp,2025-02-08,32,quantile,0.99,222
+2025-01-25,3,wk inc flu hosp,2025-02-15,32,quantile,0.99,229
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.01,46
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.01,36
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.01,28
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.01,22
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.025,50
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.025,41
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.025,33
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.025,28
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.05,53
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.05,45
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.05,38
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.05,33
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.1,57
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.1,50
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.1,43
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.1,39
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.15,59
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.15,53
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.15,47
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.15,43
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.2,61
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.2,55
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.2,50
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.2,46
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.25,63
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.25,57
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.25,52
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.25,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.3,64
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.3,59
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.3,54
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.3,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.35,65
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.35,61
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.35,56
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.35,54
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.4,67
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.4,63
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.4,58
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.4,56
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.45,68
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.45,64
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.45,60
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.45,58
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.5,69
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.5,66
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.5,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.5,60
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.55,70
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.55,68
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.55,64
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.55,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.6,72
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.6,69
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.6,66
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.6,64
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.65,73
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.65,71
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.65,68
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.65,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.7,74
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.7,73
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.7,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.7,69
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.75,76
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.75,75
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.75,72
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.75,71
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.8,77
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.8,77
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.8,75
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.8,74
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.85,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.85,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.85,77
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.85,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.9,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.9,82
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.9,81
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.9,81
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.95,85
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.95,87
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.95,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.95,87
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.975,88
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.975,91
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.975,91
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.975,92
+2025-01-25,0,wk inc flu hosp,2025-01-25,33,quantile,0.99,92
+2025-01-25,1,wk inc flu hosp,2025-02-01,33,quantile,0.99,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,33,quantile,0.99,97
+2025-01-25,3,wk inc flu hosp,2025-02-15,33,quantile,0.99,98
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.01,1118
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.01,1099
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.01,1054
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.01,1028
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.025,1138
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.025,1127
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.025,1091
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.025,1071
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.05,1154
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.05,1151
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.05,1122
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.05,1109
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.1,1174
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.1,1179
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.1,1158
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.1,1152
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.15,1186
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.15,1198
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.15,1182
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.15,1181
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.2,1197
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.2,1213
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.2,1201
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.2,1204
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.25,1206
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.25,1225
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.25,1218
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.25,1224
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.3,1214
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.3,1237
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.3,1233
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.3,1241
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.35,1221
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.35,1248
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.35,1247
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.35,1258
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.4,1228
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.4,1258
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.4,1260
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.4,1273
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.45,1235
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.45,1268
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.45,1272
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.45,1288
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.5,1241
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.5,1277
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.5,1285
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.5,1303
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.55,1248
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.55,1287
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.55,1297
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.55,1318
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.6,1255
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.6,1297
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.6,1310
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.6,1333
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.65,1262
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.65,1307
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.65,1323
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.65,1349
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.7,1269
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.7,1318
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.7,1337
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.7,1365
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.75,1277
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.75,1329
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.75,1352
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.75,1383
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.8,1286
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.8,1342
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.8,1368
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.8,1403
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.85,1296
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.85,1357
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.85,1388
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.85,1426
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.9,1309
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.9,1376
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.9,1412
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.9,1455
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.95,1328
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.95,1404
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.95,1448
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.95,1498
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.975,1345
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.975,1428
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.975,1479
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.975,1535
+2025-01-25,0,wk inc flu hosp,2025-01-25,34,quantile,0.99,1364
+2025-01-25,1,wk inc flu hosp,2025-02-01,34,quantile,0.99,1456
+2025-01-25,2,wk inc flu hosp,2025-02-08,34,quantile,0.99,1515
+2025-01-25,3,wk inc flu hosp,2025-02-15,34,quantile,0.99,1579
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.01,209
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.01,188
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.01,167
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.01,149
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.025,214
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.025,196
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.025,178
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.025,163
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.05,218
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.05,203
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.05,188
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.05,175
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.1,223
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.1,212
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.1,199
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.1,189
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.15,227
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.15,217
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.15,206
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.15,198
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.2,229
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.2,222
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.2,213
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.2,206
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.25,232
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.25,225
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.25,218
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.25,212
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.3,234
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.3,229
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.3,222
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.3,218
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.35,236
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.35,232
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.35,227
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.35,223
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.4,238
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.4,235
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.4,231
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.4,229
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.45,239
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.45,238
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.45,235
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.45,233
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.5,241
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.5,241
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.5,239
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.5,238
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.55,243
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.55,244
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.55,242
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.55,243
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.6,245
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.6,246
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.6,246
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.6,248
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.65,247
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.65,249
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.65,251
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.65,253
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.7,249
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.7,253
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.7,255
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.7,259
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.75,251
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.75,256
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.75,259
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.75,264
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.8,253
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.8,260
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.8,265
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.8,271
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.85,256
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.85,264
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.85,271
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.85,278
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.9,259
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.9,270
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.9,278
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.9,288
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.95,264
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.95,278
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.95,290
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.95,302
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.975,269
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.975,285
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.975,299
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.975,314
+2025-01-25,0,wk inc flu hosp,2025-01-25,35,quantile,0.99,274
+2025-01-25,1,wk inc flu hosp,2025-02-01,35,quantile,0.99,294
+2025-01-25,2,wk inc flu hosp,2025-02-08,35,quantile,0.99,311
+2025-01-25,3,wk inc flu hosp,2025-02-15,35,quantile,0.99,328
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.01,2430
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.01,2342
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.01,2212
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.01,2103
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.025,2472
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.025,2415
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.025,2314
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.025,2230
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.05,2509
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.05,2478
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.05,2401
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.05,2340
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.1,2551
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.1,2551
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.1,2502
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.1,2467
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.15,2579
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.15,2600
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.15,2570
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.15,2552
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.2,2602
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.2,2639
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.2,2624
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.2,2620
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.25,2621
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.25,2672
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.25,2670
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.25,2679
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.3,2639
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.3,2702
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.3,2712
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.3,2731
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.35,2655
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.35,2730
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.35,2750
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.35,2779
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.4,2670
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.4,2756
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.4,2787
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.4,2825
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.45,2685
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.45,2782
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.45,2822
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.45,2870
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.5,2699
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.5,2807
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.5,2857
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.5,2914
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.55,2714
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.55,2832
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.55,2892
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.55,2958
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.6,2729
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.6,2858
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.6,2927
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.6,3002
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.65,2744
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.65,2884
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.65,2964
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.65,3048
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.7,2760
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.7,2912
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.7,3002
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.7,3097
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.75,2778
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.75,2942
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.75,3044
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.75,3149
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.8,2797
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.8,2975
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.8,3090
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.8,3207
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.85,2819
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.85,3014
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.85,3144
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.85,3275
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.9,2848
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.9,3063
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.9,3212
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.9,3361
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.95,2890
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.95,3136
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.95,3313
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.95,3487
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.975,2926
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.975,3199
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.975,3400
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.975,3597
+2025-01-25,0,wk inc flu hosp,2025-01-25,36,quantile,0.99,2969
+2025-01-25,1,wk inc flu hosp,2025-02-01,36,quantile,0.99,3272
+2025-01-25,2,wk inc flu hosp,2025-02-08,36,quantile,0.99,3502
+2025-01-25,3,wk inc flu hosp,2025-02-15,36,quantile,0.99,3725
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.01,313
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.01,115
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.01,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.025,426
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.025,261
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.025,92
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.025,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.05,523
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.05,387
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.05,245
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.05,111
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.1,634
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.1,532
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.1,420
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.1,316
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.15,710
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.15,630
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.15,539
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.15,455
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.2,770
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.2,707
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.2,633
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.2,565
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.25,821
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.25,774
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.25,714
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.25,660
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.3,867
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.3,834
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.3,786
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.3,745
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.35,910
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.35,889
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.35,854
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.35,823
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.4,951
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.4,942
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.4,917
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.4,898
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.45,990
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.45,993
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.45,979
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.45,970
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.5,1029
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.5,1043
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.5,1040
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.5,1041
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.55,1068
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.55,1093
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.55,1101
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.55,1112
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.6,1107
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.6,1144
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.6,1162
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.6,1185
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.65,1147
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.65,1197
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.65,1226
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.65,1259
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.7,1190
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.7,1252
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.7,1293
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.7,1338
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.75,1236
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.75,1312
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.75,1366
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.75,1423
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.8,1288
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.8,1379
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.8,1447
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.8,1517
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.85,1348
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.85,1456
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.85,1541
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.85,1627
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.9,1423
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.9,1554
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.9,1660
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.9,1766
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.95,1535
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.95,1699
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.95,1835
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.95,1972
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.975,1632
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.975,1825
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.975,1988
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.975,2150
+2025-01-25,0,wk inc flu hosp,2025-01-25,37,quantile,0.99,1745
+2025-01-25,1,wk inc flu hosp,2025-02-01,37,quantile,0.99,1971
+2025-01-25,2,wk inc flu hosp,2025-02-08,37,quantile,0.99,2165
+2025-01-25,3,wk inc flu hosp,2025-02-15,37,quantile,0.99,2357
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.01,16
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.01,0
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.01,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.025,22
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.025,8
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.025,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.025,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.05,28
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.05,15
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.05,6
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.05,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.1,34
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.1,23
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.1,15
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.1,11
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.15,38
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.15,29
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.15,22
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.15,18
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.2,41
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.2,33
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.2,27
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.2,23
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.25,44
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.25,37
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.25,31
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.25,28
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.3,46
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.3,40
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.3,35
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.3,32
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.35,48
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.35,43
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.35,39
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.35,36
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.4,51
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.4,46
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.4,42
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.4,40
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.45,53
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.45,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.45,45
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.45,44
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.5,55
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.5,52
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.5,49
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.5,47
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.55,57
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.55,55
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.55,52
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.55,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.6,59
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.6,58
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.6,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.6,54
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.65,61
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.65,60
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.65,59
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.65,58
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.7,63
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.7,64
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.7,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.7,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.75,66
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.75,67
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.75,66
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.75,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.8,69
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.8,71
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.8,71
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.8,71
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.85,72
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.85,75
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.85,76
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.85,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.9,76
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.9,81
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.9,82
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.9,84
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.95,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.95,89
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.95,91
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.95,94
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.975,87
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.975,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.975,99
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.975,103
+2025-01-25,0,wk inc flu hosp,2025-01-25,38,quantile,0.99,93
+2025-01-25,1,wk inc flu hosp,2025-02-01,38,quantile,0.99,104
+2025-01-25,2,wk inc flu hosp,2025-02-08,38,quantile,0.99,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,38,quantile,0.99,113
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.01,1035
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.01,991
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.01,933
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.01,887
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.025,1056
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.025,1024
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.025,978
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.025,942
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.05,1073
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.05,1053
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.05,1016
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.05,989
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.1,1094
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.1,1086
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.1,1060
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.1,1043
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.15,1108
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.15,1108
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.15,1090
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.15,1080
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.2,1119
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.2,1126
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.2,1114
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.2,1109
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.25,1128
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.25,1141
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.25,1134
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.25,1134
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.3,1136
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.3,1155
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.3,1152
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.3,1156
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.35,1144
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.35,1167
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.35,1169
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.35,1177
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.4,1152
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.4,1179
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.4,1185
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.4,1197
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.45,1159
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.45,1191
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.45,1201
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.45,1216
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.5,1166
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.5,1202
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.5,1216
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.5,1235
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.55,1173
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.55,1214
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.55,1231
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.55,1254
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.6,1180
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.6,1225
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.6,1247
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.6,1273
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.65,1188
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.65,1237
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.65,1263
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.65,1293
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.7,1196
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.7,1250
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.7,1280
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.7,1313
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.75,1204
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.75,1263
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.75,1298
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.75,1336
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.8,1213
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.8,1278
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.8,1318
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.8,1361
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.85,1224
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.85,1296
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.85,1342
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.85,1390
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.9,1238
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.9,1318
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.9,1372
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.9,1427
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.95,1259
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.95,1351
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.95,1416
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.95,1481
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.975,1276
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.975,1380
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.975,1454
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.975,1528
+2025-01-25,0,wk inc flu hosp,2025-01-25,39,quantile,0.99,1297
+2025-01-25,1,wk inc flu hosp,2025-02-01,39,quantile,0.99,1413
+2025-01-25,2,wk inc flu hosp,2025-02-08,39,quantile,0.99,1499
+2025-01-25,3,wk inc flu hosp,2025-02-15,39,quantile,0.99,1583
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.01,256
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.01,220
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.01,181
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.01,152
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.025,267
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.025,238
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.025,205
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.025,181
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.05,276
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.05,253
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.05,225
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.05,206
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.1,287
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.1,270
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.1,249
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.1,234
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.15,294
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.15,282
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.15,264
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.15,254
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.2,300
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.2,292
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.2,277
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.2,269
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.25,305
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.25,300
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.25,288
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.25,282
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.3,310
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.3,307
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.3,297
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.3,294
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.35,314
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.35,314
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.35,306
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.35,305
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.4,318
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.4,320
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.4,315
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.4,315
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.45,321
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.45,326
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.45,323
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.45,325
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.5,325
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.5,332
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.5,331
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.5,335
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.55,329
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.55,338
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.55,339
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.55,345
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.6,333
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.6,344
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.6,347
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.6,355
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.65,337
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.65,351
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.65,356
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.65,366
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.7,341
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.7,358
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.7,365
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.7,377
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.75,345
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.75,365
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.75,375
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.75,389
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.8,350
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.8,373
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.8,385
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.8,402
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.85,356
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.85,382
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.85,398
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.85,417
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.9,363
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.9,394
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.9,414
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.9,437
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.95,374
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.95,412
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.95,437
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.95,465
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.975,383
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.975,427
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.975,457
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.975,490
+2025-01-25,0,wk inc flu hosp,2025-01-25,40,quantile,0.99,394
+2025-01-25,1,wk inc flu hosp,2025-02-01,40,quantile,0.99,444
+2025-01-25,2,wk inc flu hosp,2025-02-08,40,quantile,0.99,481
+2025-01-25,3,wk inc flu hosp,2025-02-15,40,quantile,0.99,519
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.01,180
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.01,94
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.01,16
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.025,189
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.025,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.025,38
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.025,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.05,197
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.05,124
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.05,57
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.05,4
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.1,206
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.1,140
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.1,80
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.1,32
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.15,212
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.15,150
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.15,95
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.15,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.2,216
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.2,159
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.2,107
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.2,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.25,220
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.25,166
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.25,117
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.25,79
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.3,224
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.3,173
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.3,126
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.3,90
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.35,227
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.35,179
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.35,135
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.35,101
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.4,231
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.4,185
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.4,143
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.4,111
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.45,234
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.45,190
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.45,151
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.45,121
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.5,237
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.5,196
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.5,158
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.5,131
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.55,240
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.55,201
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.55,166
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.55,140
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.6,243
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.6,207
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.6,174
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.6,150
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.65,246
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.65,213
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.65,182
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.65,160
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.7,249
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.7,219
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.7,190
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.7,171
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.75,253
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.75,225
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.75,200
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.75,182
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.8,257
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.8,232
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.8,210
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.8,195
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.85,262
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.85,241
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.85,222
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.85,210
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.9,268
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.9,252
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.9,237
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.9,229
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.95,277
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.95,268
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.95,259
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.95,257
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.975,284
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.975,281
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.975,278
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.975,281
+2025-01-25,0,wk inc flu hosp,2025-01-25,41,quantile,0.99,293
+2025-01-25,1,wk inc flu hosp,2025-02-01,41,quantile,0.99,297
+2025-01-25,2,wk inc flu hosp,2025-02-08,41,quantile,0.99,301
+2025-01-25,3,wk inc flu hosp,2025-02-15,41,quantile,0.99,309
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.01,1192
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.01,1045
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.01,822
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.01,634
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.025,1360
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.025,1253
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.025,1068
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.025,915
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.05,1505
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.05,1433
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.05,1279
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.05,1156
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.1,1671
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.1,1640
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.1,1523
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.1,1435
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.15,1784
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.15,1779
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.15,1688
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.15,1622
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.2,1873
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.2,1890
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.2,1819
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.2,1772
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.25,1950
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.25,1985
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.25,1931
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.25,1900
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.3,2019
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.3,2071
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.3,2032
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.3,2015
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.35,2083
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.35,2150
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.35,2126
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.35,2121
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.4,2143
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.4,2225
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.4,2214
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.4,2223
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.45,2202
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.45,2298
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.45,2300
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.45,2320
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.5,2259
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.5,2369
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.5,2384
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.5,2417
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.55,2317
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.55,2441
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.55,2469
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.55,2513
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.6,2376
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.6,2514
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.6,2555
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.6,2611
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.65,2436
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.65,2589
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.65,2643
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.65,2712
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.7,2500
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.7,2668
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.7,2737
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.7,2819
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.75,2569
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.75,2754
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.75,2838
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.75,2934
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.8,2645
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.8,2849
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.8,2950
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.8,3062
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.85,2735
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.85,2960
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.85,3081
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.85,3211
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.9,2847
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.9,3099
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.9,3245
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.9,3399
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.95,3014
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.95,3306
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.95,3489
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.95,3677
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.975,3158
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.975,3486
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.975,3701
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.975,3919
+2025-01-25,0,wk inc flu hosp,2025-01-25,42,quantile,0.99,3326
+2025-01-25,1,wk inc flu hosp,2025-02-01,42,quantile,0.99,3694
+2025-01-25,2,wk inc flu hosp,2025-02-08,42,quantile,0.99,3947
+2025-01-25,3,wk inc flu hosp,2025-02-15,42,quantile,0.99,4200
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.01,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.01,67
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.01,57
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.01,50
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.025,82
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.025,72
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.025,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.025,56
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.05,85
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.05,76
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.05,67
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.05,61
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.1,89
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.1,81
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.1,73
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.1,67
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.15,91
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.15,84
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.15,76
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.15,71
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.2,93
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.2,86
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.2,79
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.2,75
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.25,95
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.25,89
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.25,82
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.25,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.3,96
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.3,90
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.3,84
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.3,80
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.35,97
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.35,92
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.35,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.35,82
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.4,99
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.4,94
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.4,88
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.4,84
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.45,100
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.45,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.45,90
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.45,87
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.5,101
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.5,97
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.5,92
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.5,89
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.55,102
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.55,99
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.55,94
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.55,91
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.6,103
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.6,100
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.6,96
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.6,93
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.65,105
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.65,102
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.65,98
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.65,95
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.7,106
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.7,104
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.7,100
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.7,98
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.75,107
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.75,106
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.75,102
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.75,100
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.8,109
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.8,108
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.8,105
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.8,103
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.85,111
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.85,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.85,108
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.85,106
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.9,113
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.9,113
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.9,111
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.9,110
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.95,116
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.95,118
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.95,117
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.95,116
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.975,119
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.975,122
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.975,121
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.975,122
+2025-01-25,0,wk inc flu hosp,2025-01-25,44,quantile,0.99,123
+2025-01-25,1,wk inc flu hosp,2025-02-01,44,quantile,0.99,127
+2025-01-25,2,wk inc flu hosp,2025-02-08,44,quantile,0.99,127
+2025-01-25,3,wk inc flu hosp,2025-02-15,44,quantile,0.99,128
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.01,552
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.01,531
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.01,508
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.01,499
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.025,562
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.025,546
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.025,527
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.025,520
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.05,570
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.05,558
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.05,542
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.05,539
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.1,580
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.1,573
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.1,561
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.1,561
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.15,586
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.15,582
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.15,573
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.15,575
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.2,591
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.2,590
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.2,583
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.2,587
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.25,596
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.25,597
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.25,591
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.25,596
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.3,600
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.3,603
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.3,599
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.3,605
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.35,603
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.35,608
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.35,606
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.35,614
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.4,607
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.4,614
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.4,612
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.4,621
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.45,610
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.45,619
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.45,619
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.45,629
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.5,613
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.5,624
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.5,625
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.5,636
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.55,617
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.55,629
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.55,631
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.55,644
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.6,620
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.6,634
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.6,638
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.6,651
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.65,623
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.65,639
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.65,644
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.65,659
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.7,627
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.7,645
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.7,651
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.7,667
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.75,631
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.75,651
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.75,659
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.75,676
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.8,635
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.8,657
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.8,667
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.8,686
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.85,640
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.85,665
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.85,677
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.85,698
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.9,647
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.9,675
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.9,689
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.9,712
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.95,656
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.95,689
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.95,708
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.95,734
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.975,665
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.975,702
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.975,723
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.975,752
+2025-01-25,0,wk inc flu hosp,2025-01-25,45,quantile,0.99,674
+2025-01-25,1,wk inc flu hosp,2025-02-01,45,quantile,0.99,716
+2025-01-25,2,wk inc flu hosp,2025-02-08,45,quantile,0.99,742
+2025-01-25,3,wk inc flu hosp,2025-02-15,45,quantile,0.99,774
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.01,12
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.01,0
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.01,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.025,18
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.025,6
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.025,0
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.025,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.05,23
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.05,13
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.05,5
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.05,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.1,30
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.1,21
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.1,15
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.1,10
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.15,34
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.15,27
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.15,21
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.15,17
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.2,37
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.2,31
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.2,26
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.2,23
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.25,40
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.25,35
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.25,31
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.25,28
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.3,42
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.3,38
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.3,35
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.3,32
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.35,45
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.35,41
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.35,38
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.35,36
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.4,47
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.4,44
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.4,42
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.4,40
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.45,49
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.45,47
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.45,45
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.45,44
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.5,51
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.5,50
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.5,48
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.5,47
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.55,53
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.55,53
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.55,52
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.55,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.6,56
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.6,56
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.6,55
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.6,54
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.65,58
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.65,59
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.65,58
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.65,58
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.7,60
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.7,62
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.7,62
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.7,62
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.75,63
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.75,65
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.75,66
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.75,66
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.8,66
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.8,69
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.8,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.8,71
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.85,69
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.85,74
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.85,75
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.85,77
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.9,73
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.9,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.9,82
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.9,84
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.95,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.95,87
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.95,91
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.95,94
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.975,85
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.975,95
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.975,99
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.975,103
+2025-01-25,0,wk inc flu hosp,2025-01-25,46,quantile,0.99,91
+2025-01-25,1,wk inc flu hosp,2025-02-01,46,quantile,0.99,103
+2025-01-25,2,wk inc flu hosp,2025-02-08,46,quantile,0.99,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,46,quantile,0.99,114
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.01,263
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.01,138
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.01,10
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.025,315
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.025,212
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.025,104
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.025,10
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.05,360
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.05,277
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.05,184
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.05,106
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.1,411
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.1,351
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.1,277
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.1,216
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.15,446
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.15,401
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.15,340
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.15,291
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.2,473
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.2,440
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.2,390
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.2,350
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.25,497
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.25,474
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.25,432
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.25,400
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.3,518
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.3,505
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.3,471
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.3,446
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.35,538
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.35,533
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.35,506
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.35,488
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.4,556
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.4,560
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.4,540
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.4,528
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.45,574
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.45,586
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.45,573
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.45,567
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.5,592
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.5,612
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.5,605
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.5,605
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.55,610
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.55,637
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.55,637
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.55,643
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.6,628
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.6,663
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.6,669
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.6,682
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.65,647
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.65,690
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.65,703
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.65,722
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.7,666
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.7,719
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.7,739
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.7,764
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.75,687
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.75,749
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.75,777
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.75,810
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.8,711
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.8,783
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.8,820
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.8,861
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.85,739
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.85,823
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.85,870
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.85,920
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.9,773
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.9,873
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.9,932
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.9,994
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.95,824
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.95,947
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.95,1025
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.95,1104
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.975,869
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.975,1011
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.975,1106
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.975,1200
+2025-01-25,0,wk inc flu hosp,2025-01-25,47,quantile,0.99,921
+2025-01-25,1,wk inc flu hosp,2025-02-01,47,quantile,0.99,1086
+2025-01-25,2,wk inc flu hosp,2025-02-08,47,quantile,0.99,1199
+2025-01-25,3,wk inc flu hosp,2025-02-15,47,quantile,0.99,1311
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.01,1888
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.01,1722
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.01,1559
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.01,1456
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.025,1961
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.025,1822
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.025,1681
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.025,1596
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.05,2023
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.05,1908
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.05,1785
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.05,1716
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.1,2095
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.1,2007
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.1,1905
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.1,1855
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.15,2143
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.15,2074
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.15,1987
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.15,1948
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.2,2182
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.2,2127
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.2,2051
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.2,2022
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.25,2215
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.25,2172
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.25,2106
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.25,2086
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.3,2245
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.3,2213
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.3,2156
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.3,2143
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.35,2272
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.35,2251
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.35,2202
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.35,2196
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.4,2298
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.4,2287
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.4,2246
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.4,2246
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.45,2323
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.45,2322
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.45,2288
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.45,2295
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.5,2348
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.5,2356
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.5,2330
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.5,2343
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.55,2373
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.55,2391
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.55,2372
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.55,2391
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.6,2398
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.6,2425
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.6,2414
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.6,2439
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.65,2425
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.65,2461
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.65,2458
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.65,2490
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.7,2452
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.7,2499
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.7,2504
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.7,2543
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.75,2482
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.75,2540
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.75,2553
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.75,2600
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.8,2515
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.8,2586
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.8,2609
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.8,2664
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.85,2553
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.85,2639
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.85,2673
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.85,2738
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.9,2602
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.9,2706
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.9,2755
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.9,2831
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.95,2674
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.95,2805
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.95,2875
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.95,2970
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.975,2736
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.975,2891
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.975,2979
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.975,3090
+2025-01-25,0,wk inc flu hosp,2025-01-25,48,quantile,0.99,2808
+2025-01-25,1,wk inc flu hosp,2025-02-01,48,quantile,0.99,2991
+2025-01-25,2,wk inc flu hosp,2025-02-08,48,quantile,0.99,3101
+2025-01-25,3,wk inc flu hosp,2025-02-15,48,quantile,0.99,3229
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.01,122
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.01,94
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.01,68
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.01,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.025,127
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.025,102
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.025,79
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.025,63
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.05,132
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.05,110
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.05,89
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.05,75
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.1,137
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.1,118
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.1,100
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.1,88
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.15,141
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.15,124
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.15,108
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.15,98
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.2,144
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.2,129
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.2,114
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.2,105
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.25,147
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.25,133
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.25,119
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.25,111
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.3,149
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.3,136
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.3,124
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.3,117
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.35,151
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.35,140
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.35,128
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.35,122
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.4,153
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.4,143
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.4,132
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.4,127
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.45,155
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.45,146
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.45,136
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.45,132
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.5,157
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.5,149
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.5,140
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.5,136
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.55,159
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.55,152
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.55,144
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.55,141
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.6,161
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.6,155
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.6,148
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.6,146
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.65,163
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.65,158
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.65,152
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.65,151
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.7,165
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.7,161
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.7,156
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.7,156
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.75,167
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.75,165
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.75,161
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.75,162
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.8,169
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.8,169
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.8,166
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.8,168
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.85,172
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.85,173
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.85,172
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.85,175
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.9,176
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.9,179
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.9,180
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.9,184
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.95,182
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.95,188
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.95,191
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.95,198
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.975,186
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.975,195
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.975,201
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.975,210
+2025-01-25,0,wk inc flu hosp,2025-01-25,49,quantile,0.99,192
+2025-01-25,1,wk inc flu hosp,2025-02-01,49,quantile,0.99,204
+2025-01-25,2,wk inc flu hosp,2025-02-08,49,quantile,0.99,212
+2025-01-25,3,wk inc flu hosp,2025-02-15,49,quantile,0.99,223
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.01,17
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.01,12
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.01,5
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.025,20
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.025,16
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.025,11
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.025,6
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.05,23
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.05,20
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.05,16
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.05,12
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.1,27
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.1,25
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.1,21
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.1,18
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.15,29
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.15,28
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.15,25
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.15,22
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.2,31
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.2,30
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.2,28
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.2,25
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.25,33
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.25,32
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.25,30
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.25,28
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.3,34
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.3,34
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.3,32
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.3,31
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.35,36
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.35,36
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.35,34
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.35,33
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.4,37
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.4,38
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.4,36
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.4,35
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.45,38
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.45,39
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.45,38
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.45,38
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.5,39
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.5,41
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.5,40
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.5,40
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.55,41
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.55,42
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.55,42
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.55,42
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.6,42
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.6,44
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.6,44
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.6,44
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.65,43
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.65,46
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.65,46
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.65,46
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.7,45
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.7,47
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.7,48
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.7,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.75,46
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.75,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.75,50
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.75,51
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.8,48
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.8,51
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.8,53
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.8,54
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.85,50
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.85,54
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.85,56
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.85,57
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.9,52
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.9,57
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.9,59
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.9,61
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.95,55
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.95,62
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.95,65
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.95,68
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.975,59
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.975,66
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.975,70
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.975,73
+2025-01-25,0,wk inc flu hosp,2025-01-25,50,quantile,0.99,62
+2025-01-25,1,wk inc flu hosp,2025-02-01,50,quantile,0.99,70
+2025-01-25,2,wk inc flu hosp,2025-02-08,50,quantile,0.99,75
+2025-01-25,3,wk inc flu hosp,2025-02-15,50,quantile,0.99,79
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.01,353
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.01,311
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.01,266
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.01,237
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.025,370
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.025,335
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.025,296
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.025,272
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.05,385
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.05,356
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.05,322
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.05,303
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.1,402
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.1,380
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.1,352
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.1,338
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.15,414
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.15,397
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.15,373
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.15,361
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.2,423
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.2,410
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.2,389
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.2,380
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.25,431
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.25,421
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.25,403
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.25,396
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.3,438
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.3,431
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.3,415
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.3,411
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.35,444
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.35,440
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.35,427
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.35,424
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.4,450
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.4,449
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.4,438
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.4,437
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.45,456
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.45,458
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.45,448
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.45,449
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.5,462
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.5,466
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.5,459
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.5,461
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.55,468
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.55,474
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.55,469
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.55,473
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.6,474
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.6,483
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.6,480
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.6,486
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.65,481
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.65,492
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.65,491
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.65,498
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.7,487
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.7,501
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.7,502
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.7,512
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.75,494
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.75,511
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.75,515
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.75,526
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.8,502
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.8,522
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.8,529
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.8,542
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.85,511
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.85,535
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.85,545
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.85,561
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.9,523
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.9,552
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.9,565
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.9,585
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.95,540
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.95,576
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.95,595
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.95,620
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.975,555
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.975,597
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.975,621
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.975,650
+2025-01-25,0,wk inc flu hosp,2025-01-25,51,quantile,0.99,572
+2025-01-25,1,wk inc flu hosp,2025-02-01,51,quantile,0.99,621
+2025-01-25,2,wk inc flu hosp,2025-02-08,51,quantile,0.99,652
+2025-01-25,3,wk inc flu hosp,2025-02-15,51,quantile,0.99,686
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.01,439
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.01,405
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.01,370
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.01,343
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.025,449
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.025,420
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.025,391
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.025,368
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.05,458
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.05,434
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.05,409
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.05,390
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.1,468
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.1,449
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.1,429
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.1,415
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.15,474
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.15,459
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.15,443
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.15,432
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.2,479
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.2,467
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.2,454
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.2,446
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.25,484
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.25,474
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.25,463
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.25,457
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.3,488
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.3,481
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.3,472
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.3,467
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.35,492
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.35,487
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.35,480
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.35,477
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.4,495
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.4,492
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.4,487
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.4,486
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.45,499
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.45,497
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.45,494
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.45,495
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.5,502
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.5,503
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.5,501
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.5,504
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.55,506
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.55,508
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.55,508
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.55,512
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.6,509
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.6,513
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.6,515
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.6,521
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.65,513
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.65,519
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.65,523
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.65,530
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.7,516
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.7,525
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.7,531
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.7,540
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.75,520
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.75,531
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.75,539
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.75,550
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.8,525
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.8,538
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.8,549
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.8,562
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.85,530
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.85,546
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.85,560
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.85,575
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.9,537
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.9,557
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.9,573
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.9,592
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.95,546
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.95,572
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.95,594
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.95,618
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.975,555
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.975,585
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.975,612
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.975,639
+2025-01-25,0,wk inc flu hosp,2025-01-25,53,quantile,0.99,565
+2025-01-25,1,wk inc flu hosp,2025-02-01,53,quantile,0.99,601
+2025-01-25,2,wk inc flu hosp,2025-02-08,53,quantile,0.99,632
+2025-01-25,3,wk inc flu hosp,2025-02-15,53,quantile,0.99,665
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.01,100
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.01,88
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.01,76
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.01,67
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.025,106
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.025,96
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.025,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.025,78
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.05,110
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.05,102
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.05,94
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.05,87
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.1,115
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.1,109
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.1,103
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.1,97
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.15,119
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.15,114
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.15,109
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.15,104
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.2,122
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.2,118
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.2,114
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.2,110
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.25,124
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.25,122
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.25,118
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.25,115
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.3,126
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.3,125
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.3,121
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.3,119
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.35,128
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.35,128
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.35,125
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.35,123
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.4,130
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.4,130
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.4,128
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.4,127
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.45,132
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.45,133
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.45,131
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.45,131
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.5,134
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.5,136
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.5,135
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.5,134
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.55,136
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.55,138
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.55,138
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.55,138
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.6,138
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.6,141
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.6,141
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.6,142
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.65,140
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.65,144
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.65,144
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.65,145
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.7,142
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.7,146
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.7,148
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.7,149
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.75,144
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.75,149
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.75,151
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.75,154
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.8,146
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.8,153
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.8,156
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.8,158
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.85,149
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.85,157
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.85,160
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.85,164
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.9,153
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.9,162
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.9,167
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.9,171
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.95,158
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.95,169
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.95,176
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.95,182
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.975,162
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.975,176
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.975,184
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.975,191
+2025-01-25,0,wk inc flu hosp,2025-01-25,54,quantile,0.99,168
+2025-01-25,1,wk inc flu hosp,2025-02-01,54,quantile,0.99,183
+2025-01-25,2,wk inc flu hosp,2025-02-08,54,quantile,0.99,193
+2025-01-25,3,wk inc flu hosp,2025-02-15,54,quantile,0.99,201
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.01,538
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.01,547
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.01,536
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.01,528
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.025,547
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.025,561
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.025,556
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.025,551
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.05,555
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.05,573
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.05,572
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.05,572
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.1,563
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.1,587
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.1,591
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.1,595
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.15,569
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.15,596
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.15,604
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.15,611
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.2,574
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.2,604
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.2,614
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.2,623
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.25,578
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.25,610
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.25,622
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.25,634
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.3,582
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.3,616
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.3,630
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.3,644
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.35,585
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.35,621
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.35,638
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.35,653
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.4,588
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.4,627
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.4,644
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.4,661
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.45,591
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.45,631
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.45,651
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.45,670
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.5,594
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.5,636
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.5,658
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.5,678
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.55,597
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.55,641
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.55,664
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.55,686
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.6,600
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.6,646
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.6,671
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.6,694
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.65,604
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.65,651
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.65,678
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.65,703
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.7,607
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.7,656
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.7,685
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.7,712
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.75,611
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.75,662
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.75,693
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.75,721
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.8,615
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.8,669
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.8,701
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.8,732
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.85,619
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.85,676
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.85,712
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.85,745
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.9,625
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.9,686
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.9,724
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.9,760
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.95,634
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.95,700
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.95,743
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.95,784
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.975,641
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.975,712
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.975,760
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.975,804
+2025-01-25,0,wk inc flu hosp,2025-01-25,55,quantile,0.99,650
+2025-01-25,1,wk inc flu hosp,2025-02-01,55,quantile,0.99,726
+2025-01-25,2,wk inc flu hosp,2025-02-08,55,quantile,0.99,779
+2025-01-25,3,wk inc flu hosp,2025-02-15,55,quantile,0.99,828
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.01,38
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.01,19
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.01,5
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.01,0
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.025,45
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.025,27
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.025,15
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.025,7
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.05,50
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.05,35
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.05,23
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.05,16
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.1,57
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.1,43
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.1,33
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.1,27
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.15,61
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.15,49
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.15,40
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.15,34
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.2,64
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.2,53
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.2,45
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.2,40
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.25,67
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.25,57
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.25,49
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.25,45
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.3,70
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.3,61
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.3,53
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.3,49
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.35,72
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.35,64
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.35,57
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.35,53
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.4,75
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.4,67
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.4,61
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.4,57
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.45,77
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.45,70
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.45,64
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.45,61
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.5,79
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.5,73
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.5,67
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.5,65
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.55,81
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.55,76
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.55,71
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.55,68
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.6,83
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.6,79
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.6,74
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.6,72
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.65,86
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.65,82
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.65,78
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.65,76
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.7,88
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.7,85
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.7,81
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.7,80
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.75,91
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.75,88
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.75,86
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.75,84
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.8,94
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.8,92
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.8,90
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.8,89
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.85,97
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.85,97
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.85,95
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.85,95
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.9,101
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.9,103
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.9,102
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.9,102
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.95,108
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.95,111
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.95,111
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.95,113
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.975,113
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.975,118
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.975,120
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.975,122
+2025-01-25,0,wk inc flu hosp,2025-01-25,56,quantile,0.99,120
+2025-01-25,1,wk inc flu hosp,2025-02-01,56,quantile,0.99,127
+2025-01-25,2,wk inc flu hosp,2025-02-08,56,quantile,0.99,130
+2025-01-25,3,wk inc flu hosp,2025-02-15,56,quantile,0.99,133
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.01,24061
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.01,20319
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.01,16620
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.01,13240
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.025,25300
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.025,22243
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.025,19159
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.025,16354
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.05,26366
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.05,23898
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.05,21342
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.05,19033
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.1,27594
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.1,25805
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.1,23859
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.1,22121
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.15,28423
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.15,27092
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.15,25557
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.15,24205
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.2,29082
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.2,28115
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.2,26907
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.2,25861
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.25,29647
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.25,28993
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.25,28065
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.25,27281
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.3,30155
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.3,29781
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.3,29105
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.3,28557
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.35,30625
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.35,30511
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.35,30068
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.35,29739
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.4,31072
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.4,31204
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.4,30983
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.4,30861
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.45,31503
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.45,31875
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.45,31867
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.45,31947
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.5,31928
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.5,32535
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.5,32738
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.5,33015
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.55,32353
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.55,33194
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.55,33609
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.55,34083
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.6,32785
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.6,33865
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.6,34493
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.6,35169
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.65,33231
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.65,34558
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.65,35408
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.65,36290
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.7,33702
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.7,35288
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.7,36371
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.7,37473
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.75,34209
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.75,36076
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.75,37411
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.75,38748
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.8,34774
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.8,36954
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.8,38569
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.8,40169
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.85,35433
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.85,37977
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.85,39919
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.85,41825
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.9,36262
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.9,39264
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.9,41617
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.9,43909
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.95,37491
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.95,41171
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.95,44134
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.95,46997
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.975,38556
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.975,42826
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.975,46317
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.975,49676
+2025-01-25,0,wk inc flu hosp,2025-01-25,US,quantile,0.99,39796
+2025-01-25,1,wk inc flu hosp,2025-02-01,US,quantile,0.99,44750
+2025-01-25,2,wk inc flu hosp,2025-02-08,US,quantile,0.99,48856
+2025-01-25,3,wk inc flu hosp,2025-02-15,US,quantile,0.99,52790


### PR DESCRIPTION
NOTE: due to lack of reporting in the preliminary signal (https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/mpgq-jmmr/about_data) this week we are submitting delayed forecasts. we have used the non-preliminary signal (https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy/about_data) to fit models used in this submission.