### PR TITLE
updating hubverse org name in schema files.

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v3.0.1/admin-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/admin-schema.json",
     "name": "US CDC FluSight",
     "maintainer": "US CDC",
     "contact": {

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v3.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,


### PR DESCRIPTION
This change should have no practical impact on the running of the hub, as the URLs are currently redirecting to the new URL anyways, but this will prevent some warning/info messages that are posted when validating/connecting to the hub.