### PR TITLE
Update LosAlamos_NAU-CModel_Flu.yml

### DIFF
--- a/model-metadata/LosAlamos_NAU-CModel_Flu.yml
+++ b/model-metadata/LosAlamos_NAU-CModel_Flu.yml
@@ -54,27 +54,27 @@ model_contributors: [
             "affiliation": "Northern Arizona University",
             "email": "bjf235@nau.edu",
         },
-	{
+        {
             "name": "Kylie Ann Geist",
             "affiliation": "Northern Arizona University",
             "email": "kag592@nau.edu",
         },
-	{
+        {
             "name": "Ely Finn Miller",
             "affiliation": "Northern Arizona University",
             "email": "efm46@nau.edu",
         },
-	{
+        {
             "name": "Amir Aman Gill",
             "affiliation": "Northern Arizona University",
             "email": "aag674@nau.edu",
         },
-	{
+        {
             "name": "Y-Minh B Truong",
             "affiliation": "Northern Arizona University",
             "email": "ybt4@nau.edu",
         },
-	{
+        {
             "name": "Ozbej Bernik",
             "affiliation": "Northern Arizona University",
             "email": "ob244@nau.edu",


### PR DESCRIPTION
This fixes tabs to be spaces.

This fixes the following error [from the dashboard build process](https://github.com/reichlab/flusight-dashboard/actions/runs/14040356629/job/39308730612):

```
found character '\t' that cannot start any token
  in "repo/model-metadata/LosAlamos_NAU-CModel_Flu.yml", line 57, column 1
```