### PR TITLE
push target data directly to main

### DIFF
--- a/.github/workflows/update_target_data.yml
+++ b/.github/workflows/update_target_data.yml
@@ -2,9 +2,6 @@ name: Update target data
 on:
   workflow_dispatch:
     inputs:
-      name:
-        description: 'Update target data'
-        required: false
       publish:
         description: 'Publish the target data'
         type: boolean

--- a/.github/workflows/update_target_data.yml
+++ b/.github/workflows/update_target_data.yml
@@ -44,14 +44,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_DATETIME=$(date +'%Y-%m-%d_%H-%M-%S')
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b update/targets/"$PR_DATETIME"
           git add target-data/
           git commit -m "Update target data" || echo nothing to commit
-          git push -u origin update/targets/"$PR_DATETIME"
-          gh pr create \
-            --base main \
-            --title "Update target data $PR_DATETIME" \
-            --body "This PR was created via GitHub Actions: update target data."
+          git push origin main


### PR DESCRIPTION
Before we incorporated hubverse-formatted target data (see #2122), the time series data were updated automatically via this workflow, which would push directly to the main branch.

When we incorporated the hubverse-formatted target data, we wanted to propose having the target data update via pull request (see and https://github.com/reichlab/FluSight-forecast-hub/pull/5). However, due to a mistake, the workflow was implemented without review.

This is the opportunity to review the workflow. 

@Annabella-Hines, at the moment the target data will be updated via a pull request. Would you prefer to go back to the old method where the target data are automatically updated on the main branch? 