### PR TITLE
Increase oracle output generation range to include 2023-2024 season

### DIFF
--- a/target-data/get_target_data_hubverse.R
+++ b/target-data/get_target_data_hubverse.R
@@ -502,7 +502,7 @@ run_target_data_tests <- function() {
 #' @param oracle_include_after "YYYY-MM_DD" string. Base target data dated on or earlier will be excluded.
 #' @param target_data_path Path to the target data directory.
 #' @return NULL
-create_target_data <- function(as_of = NULL, oracle_include_after = "2024-11-01", target_data_path) {
+create_target_data <- function(as_of = NULL, oracle_include_after = "2023-09-22", target_data_path) {
   # Validate input params
   tryCatch(
     as.Date(oracle_include_after, format = "%Y-%m-%d"),
@@ -552,7 +552,7 @@ create_target_data <- function(as_of = NULL, oracle_include_after = "2024-11-01"
   oracle_output_target <- oracle_output_target |>
     dplyr::select(all_of(oracle_col_order), everything())
 
- # Write updated target data files
+  # Write updated target data files
   if (!dir.exists(target_data_path)) {
     dir.create(target_data_path, recursive = TRUE)
   }
@@ -578,10 +578,9 @@ as_of <- args[1]
 oracle_include_after <- args[2]
 
 # If oracle_include_after date is not provided, default to the beginning
-# of the 2024-2025 flu season (note: mandatory reporting was reinstated as
-# of 2024-11-01)
+# of the 2023-2024 flu season (start of forecasts in the hubverse format)
 if (is.na(oracle_include_after) || is.null(oracle_include_after)) {
-  oracle_include_after <- "2024-10-31"
+  oracle_include_after <- "2023-09-22"
 }
 
 # Run tests


### PR DESCRIPTION
In order to add the 2023/2024 season forecasts to the dashboard, we need to have corresponding target data in the form of oracle output so that those forecasts can be evaluated. This change to the target data generation code adds oracle values for the 2023/2024 season to the oracle-output.csv file.

Once this pull request is merged in and new oracle output has been generated, I will merge some staged changes into the dashboard repo that will add the 2023/2024 season to FluSight's dashboard.