### PR TITLE
Update broken `website_url` entry on metadata

### DIFF
--- a/model-metadata/CEPH-Rtrend_fluH.yaml
+++ b/model-metadata/CEPH-Rtrend_fluH.yaml
@@ -36,4 +36,4 @@ methods: "A renewal equation method based on Bayesian estimation of Rt from hosp
 methods_long: "Model forecasts are obtained by using a renewal equation based on the estimated net reproduction number Rt. We apply a lowpass filter to the time series of daily hospitalizations, extracting the main trend. We then use MCMC Metropolis-Hastings sampling to estimate the posterior distribution of Rt based on the filtered data, considering an informed prior on Rt based on influenza literature. The estimated Rt in the last weeks of available data is used to forecast Rt in the upcoming weeks, with a drift term proportional to the current incidence.  Finally, we use the renewal equation with the posterior distribution and trend of the estimated Rt in the most recent weeks of influenza data."
 ensemble_of_models: false
 ensemble_of_hub_models: false
-website_url: https://publichealth.indiana.edu/research/faculty-directory/profile.html?user=majelli
+website_url: https://publichealth.indiana.edu/about/directory/Marco-Ajelli-majelli.html


### PR DESCRIPTION
This pull request updates the `website_url` on `CEPH-Rtrend_covid.yml`, since the last URL was broken.