### PR TITLE
Round up negative forecast to zero

### DIFF
--- a/model-output/UVAFluX-CESGCN/2025-05-24-UVAFluX-CESGCN.csv
+++ b/model-output/UVAFluX-CESGCN/2025-05-24-UVAFluX-CESGCN.csv
@@ -57,7 +57,7 @@ reference_date,target,horizon,target_end_date,location,output_type,output_type_i
 2025-05-24,wk inc flu hosp,-1,2025-05-17,15,quantile,0.01,1.8033715486526491
 2025-05-24,wk inc flu hosp,0,2025-05-24,15,quantile,0.01,0.07783169865608215
 2025-05-24,wk inc flu hosp,1,2025-05-31,15,quantile,0.01,2.571289882659912
-2025-05-24,wk inc flu hosp,2,2025-06-07,15,quantile,0.01,-0.236403439193964
+2025-05-24,wk inc flu hosp,2,2025-06-07,15,quantile,0.01,0
 2025-05-24,wk inc flu hosp,3,2025-06-14,15,quantile,0.01,3.696379132270813
 2025-05-24,wk inc flu hosp,-1,2025-05-17,16,quantile,0.01,4.804182052612305
 2025-05-24,wk inc flu hosp,0,2025-05-24,16,quantile,0.01,4.7180139827728285


### PR DESCRIPTION
While trying to add log transformed scores to the dashboard, I uncovered a negative forecast that caused the following error when I was building the scores for the evaluations dashboard:

```
Error in `purrr::map()` at hubPredEvalsData/R/generate_eval_data.R:149:3:
ℹ In index: 1.
Caused by error in `fun()`:
! Detected input values < 0.
```

I identified the forecast as being from the [2025-05-24 submission from UVAFluX-CESGCN](https://github.com/cdcepi/FluSight-forecast-hub/blob/main/model-output/UVAFluX-CESGCN/2025-05-24-UVAFluX-CESGCN.csv):
```
   model_id       reference_date target          horizon location target_end_date output_type output_type_id   value
   <chr>          <date>         <chr>             <int> <chr>    <date>          <chr>       <chr>            <dbl>
   UVAFluX-CESGCN 2025-05-24     wk inc flu hosp       2 15       2025-06-07      quantile    0.01           -0.236 
```
Note that it seems like no validation checks were run on this model output file, which might explain why the negative value slipped in despite the hub not allowing values less than zero.

Once I rounded this value up to zero, the evaluations dashboard was able to build locally. I also double checked that rounding did not cause any quantile crossing.